### PR TITLE
10X faster toUpperAsciiInPlace using general optimization trick for conditional array writes

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,4 +1,9 @@
-image: freebsd/latest
+# see https://man.sr.ht/builds.sr.ht/compatibility.md#freebsd
+# these are all broken, pending https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=244549
+# image: freebsd/latest 
+# image: freebsd/current
+# image: freebsd/12.x
+image: freebsd/11.x
 packages:
 - databases/sqlite3
 - devel/boehm-gc-threaded

--- a/changelog.md
+++ b/changelog.md
@@ -52,7 +52,7 @@
   `CountTable.pop`, `Table.pop`
 - To `strtabs.nim`, added `StringTable.clear` overload that reuses the existing mode.
 - Added `browsers.osOpen` const alias for the operating system specific *"open"* command.
-- Added `sugar.outplace` for turning in-place algorithms like `sort` and `shuffle` into
+- Added `sugar.dup` for turning in-place algorithms like `sort` and `shuffle` into
   operations that work on a copy of the data and return the mutated copy. As the existing
   `sorted` does.
 - Added `sugar.collect` that does comprehension for seq/set/table collections.
@@ -69,6 +69,18 @@
 - Added `minIndex`, `maxIndex` and `unzip` to the `sequtils` module.
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 - Added `resetOutputFormatters` to `unittest`
+
+
+- Added a `with` macro for easy function chaining that's available
+  everywhere, there is no need to concern your APIs with returning the first argument
+  to enable "chaining", instead use the dedicated macro `with` that
+  was designed for it. For example:
+
+```nim
+
+
+
+```
 
 
 ## Library changes

--- a/changelog.md
+++ b/changelog.md
@@ -81,6 +81,7 @@
 
 
 ```
+- Added `times.isLeapDay`
 
 
 ## Library changes

--- a/changelog.md
+++ b/changelog.md
@@ -98,8 +98,6 @@ echo f
 
 ## Library changes
 
-- `asynchttpserver` added an iterator that allows the request body to be read in
-   chunks of data when new server "stream" option is set to true.
 - `asyncdispatch.drain` now properly takes into account `selector.hasPendingOperations`
   and only returns once all pending async operations are guaranteed to have completed.
 - `asyncdispatch.drain` now consistently uses the passed timeout value for all

--- a/changelog.md
+++ b/changelog.md
@@ -69,7 +69,7 @@
 - Added `minIndex`, `maxIndex` and `unzip` to the `sequtils` module.
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 - Added `resetOutputFormatters` to `unittest`
-
+- Added `os.isValidFilename` that returns `true` if `filename` argument is valid for crossplatform use.
 
 - Added a `with` macro for easy function chaining that's available
   everywhere, there is no need to concern your APIs with returning the first argument

--- a/changelog.md
+++ b/changelog.md
@@ -132,3 +132,5 @@
   `ioselector_select` now properly handle the `Event.User` select event type.
 - `joinPath` path normalization when `/` is the first argument works correctly:
   `assert "/" / "/a" == "/a"`. Fixed the edgecase: `assert "" / "" == ""`.
+- `xmltree` now adds indentation consistently to child nodes for any number
+  of children nodes.

--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,8 @@
   are converted to `None`.
 - `relativePath("foo", "foo")` is now `"."`, not `""`, as `""` means invalid path
   and shouldn't be conflated with `"."`; use -d:nimOldRelativePathBehavior to restore the old
-  behavioe
+  behavior
+- `joinPath(a,b)` now honors trailing slashes in `b` (or `a` if `b` = "")
 
 ### Breaking changes in the compiler
 

--- a/changelog.md
+++ b/changelog.md
@@ -126,6 +126,7 @@
 
 ### Tool changes
 
+- Fix Nimpretty must not accept negative indentation argument because breaks file.
 
 
 ### Compiler changes

--- a/changelog.md
+++ b/changelog.md
@@ -94,6 +94,10 @@ echo f
 - Added `times.isLeapDay`
 - Added a new module, `std / compilesettings` for querying the compiler about
   diverse configuration settings.
+- Added in-place `strutils.toLowerAscii`,  `strutils.toUpperAscii`, `strutils.capitalizeAscii`,
+  with compile-time `{.linearScanEnd.}` optimizations for `string` and `char`,
+  faster than the copy versions, at least from ~1.5x to ~5x performance approx,
+  depending on how you optimize it with the `linearScanEnd` static argument.
 
 
 ## Library changes

--- a/changelog.md
+++ b/changelog.md
@@ -127,7 +127,6 @@ echo f
 - `=sink` type bound operator is now optional. Compiler can now use combination
   of `=destroy` and `copyMem` to move objects efficiently.
 
-
 ## Language changes
 
 - Unsigned integer operators have been fixed to allow promotion of the first operand.
@@ -150,6 +149,9 @@ echo f
 - The Nim compiler now supports a new pragma called ``.localPassc`` to
   pass specific compiler options to the C(++) backend for the C(++) file
   that was produced from the current Nim module.
+- The compiler now inferes "sink parameters". To disable this for a specific routine,
+  annotate it with `.nosinks`. To disable it for a section of code, use
+  `{.push sinkInference: off.}`...`{.pop.}`.
 
 
 ## Bugfixes

--- a/changelog.md
+++ b/changelog.md
@@ -94,10 +94,8 @@ echo f
 - Added `times.isLeapDay`
 - Added a new module, `std / compilesettings` for querying the compiler about
   diverse configuration settings.
-- Added in-place `strutils.toLowerAscii`,  `strutils.toUpperAscii`, `strutils.capitalizeAscii`,
-  with compile-time `{.linearScanEnd.}` optimizations for `string` and `char`,
-  faster than the copy versions, at least from ~1.5x to ~5x performance approx,
-  depending on how you optimize it with the `linearScanEnd` static argument.
+- Added in-place `strutils.toLowerAsciiInPlace`,  `strutils.toUpperAsciiInPlace`, `strutils.capitalizeAsciiInPlace`,
+  faster than the copy versions, at least from ~1.5x to ~5x performance approx.
 
 
 ## Library changes

--- a/changelog.md
+++ b/changelog.md
@@ -94,7 +94,7 @@ echo f
 - Added `times.isLeapDay`
 - Added a new module, `std / compilesettings` for querying the compiler about
   diverse configuration settings.
-- Added in-place `strutils.toLowerAsciiInPlace`,  `strutils.toUpperAsciiInPlace`, `strutils.capitalizeAsciiInPlace`,
+- Added in-place `strutils.toLowerAsciiInPlace`,  `strutils.toUpperAsciiInPlace`,
   faster than the copy versions, at least from ~1.5x to ~5x performance approx.
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -78,10 +78,22 @@
 
 ```nim
 
+type
+  Foo = object
+    col, pos: string
 
+proc setColor(f: var Foo; r, g, b: int) = f.col = $(r, g, b)
+proc setPosition(f: var Foo; x, y: float) = f.pos = $(x, y)
+
+var f: Foo
+with(f, setColor(2, 3, 4), setPosition(0.0, 1.0))
+echo f
 
 ```
+
 - Added `times.isLeapDay`
+- Added a new module, `std / compilesettings` for querying the compiler about
+  diverse configuration settings.
 
 
 ## Library changes

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -336,6 +336,8 @@ const
   tagEffects* = 3       # user defined tag ('gc', 'time' etc.)
   pragmasEffects* = 4    # not an effect, but a slot for pragmas in proc type
   effectListLen* = 5    # list of effects list
+  nkLastBlockStmts* = {nkRaiseStmt, nkReturnStmt, nkBreakStmt, nkContinueStmt}  
+                        # these must be last statements in a block
 
 type
   TTypeKind* = enum  # order is important!

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -336,7 +336,7 @@ const
   tagEffects* = 3       # user defined tag ('gc', 'time' etc.)
   pragmasEffects* = 4    # not an effect, but a slot for pragmas in proc type
   effectListLen* = 5    # list of effects list
-  nkLastBlockStmts* = {nkRaiseStmt, nkReturnStmt, nkBreakStmt, nkContinueStmt}  
+  nkLastBlockStmts* = {nkRaiseStmt, nkReturnStmt, nkBreakStmt, nkContinueStmt}
                         # these must be last statements in a block
 
 type
@@ -599,12 +599,11 @@ type
     mDefined, mDefinedInScope, mCompiles, mArrGet, mArrPut, mAsgn,
     mLow, mHigh, mSizeOf, mAlignOf, mOffsetOf, mTypeTrait,
     mIs, mOf, mAddr, mType, mTypeOf,
-    mRoof, mPlugin, mEcho, mShallowCopy, mSlurp, mStaticExec, mStatic,
+    mPlugin, mEcho, mShallowCopy, mSlurp, mStaticExec, mStatic,
     mParseExprToAst, mParseStmtToAst, mExpandToAst, mQuoteAst,
-    mUnaryLt, mInc, mDec, mOrd,
+    mInc, mDec, mOrd,
     mNew, mNewFinalize, mNewSeq, mNewSeqOfCap,
     mLengthOpenArray, mLengthStr, mLengthArray, mLengthSeq,
-    mXLenStr, mXLenSeq,
     mIncl, mExcl, mCard, mChr,
     mGCref, mGCunref,
     mAddI, mSubI, mMulI, mDivI, mModI,
@@ -620,7 +619,7 @@ type
     mEqEnum, mLeEnum, mLtEnum,
     mEqCh, mLeCh, mLtCh,
     mEqB, mLeB, mLtB,
-    mEqRef, mEqUntracedRef, mLePtr, mLtPtr,
+    mEqRef, mLePtr, mLtPtr,
     mXor, mEqCString, mEqProc,
     mUnaryMinusI, mUnaryMinusI64, mAbsI, mNot,
     mUnaryPlusI, mBitnotI,
@@ -629,18 +628,18 @@ type
     mStrToStr, mEnumToStr,
     mAnd, mOr,
     mEqStr, mLeStr, mLtStr,
-    mEqSet, mLeSet, mLtSet, mMulSet, mPlusSet, mMinusSet, mSymDiffSet,
+    mEqSet, mLeSet, mLtSet, mMulSet, mPlusSet, mMinusSet,
     mConStrStr, mSlice,
     mDotDot, # this one is only necessary to give nice compile time warnings
     mFields, mFieldPairs, mOmpParFor,
     mAppendStrCh, mAppendStrStr, mAppendSeqElem,
-    mInRange, mInSet, mRepr, mExit,
+    mInSet, mRepr, mExit,
     mSetLengthStr, mSetLengthSeq,
     mIsPartOf, mAstToStr, mParallel,
-    mSwap, mIsNil, mArrToSeq, mCopyStr, mCopyStrLast,
+    mSwap, mIsNil, mArrToSeq,
     mNewString, mNewStringOfCap, mParseBiggestFloat,
     mMove, mWasMoved, mDestroy,
-    mDefault, mUnown, mAccessEnv, mAccessTypeInfo, mReset,
+    mDefault, mUnown, mAccessEnv, mReset,
     mArray, mOpenArray, mRange, mSet, mSeq, mOpt, mVarargs,
     mRef, mPtr, mVar, mDistinct, mVoid, mTuple,
     mOrdinal,
@@ -648,8 +647,8 @@ type
     mUInt, mUInt8, mUInt16, mUInt32, mUInt64,
     mFloat, mFloat32, mFloat64, mFloat128,
     mBool, mChar, mString, mCstring,
-    mPointer, mEmptySet, mIntSetBaseType, mNil, mExpr, mStmt, mTypeDesc,
-    mVoidType, mPNimrodNode, mShared, mGuarded, mLock, mSpawn, mDeepCopy,
+    mPointer, mNil, mExpr, mStmt, mTypeDesc,
+    mVoidType, mPNimrodNode, mSpawn, mDeepCopy,
     mIsMainModule, mCompileDate, mCompileTime, mProcCall,
     mCpuEndian, mHostOS, mHostCPU, mBuildOS, mBuildCPU, mAppType,
     mCompileOption, mCompileOptionArg,
@@ -662,7 +661,7 @@ type
     mNIntVal, mNFloatVal, mNSymbol, mNIdent, mNGetType, mNStrVal, mNSetIntVal,
     mNSetFloatVal, mNSetSymbol, mNSetIdent, mNSetType, mNSetStrVal, mNLineInfo,
     mNNewNimNode, mNCopyNimNode, mNCopyNimTree, mStrToIdent, mNSigHash, mNSizeOf,
-    mNBindSym, mLocals, mNCallSite,
+    mNBindSym, mNCallSite,
     mEqIdent, mEqNimrodNode, mSameNodeType, mGetImpl, mNGenSym,
     mNHint, mNWarning, mNError,
     mInstantiationInfo, mGetTypeInfo,
@@ -673,9 +672,9 @@ type
 
 # things that we can evaluate safely at compile time, even if not asked for it:
 const
-  ctfeWhitelist* = {mNone, mUnaryLt, mSucc,
+  ctfeWhitelist* = {mNone, mSucc,
     mPred, mInc, mDec, mOrd, mLengthOpenArray,
-    mLengthStr, mLengthArray, mLengthSeq, mXLenStr, mXLenSeq,
+    mLengthStr, mLengthArray, mLengthSeq,
     mArrGet, mArrPut, mAsgn, mDestroy,
     mIncl, mExcl, mCard, mChr,
     mAddI, mSubI, mMulI, mDivI, mModI,
@@ -690,17 +689,16 @@ const
     mEqEnum, mLeEnum, mLtEnum,
     mEqCh, mLeCh, mLtCh,
     mEqB, mLeB, mLtB,
-    mEqRef, mEqProc, mEqUntracedRef, mLePtr, mLtPtr, mEqCString, mXor,
+    mEqRef, mEqProc, mLePtr, mLtPtr, mEqCString, mXor,
     mUnaryMinusI, mUnaryMinusI64, mAbsI, mNot, mUnaryPlusI, mBitnotI,
     mUnaryPlusF64, mUnaryMinusF64,
     mCharToStr, mBoolToStr, mIntToStr, mInt64ToStr, mFloatToStr, mCStrToStr,
     mStrToStr, mEnumToStr,
     mAnd, mOr,
     mEqStr, mLeStr, mLtStr,
-    mEqSet, mLeSet, mLtSet, mMulSet, mPlusSet, mMinusSet, mSymDiffSet,
+    mEqSet, mLeSet, mLtSet, mMulSet, mPlusSet, mMinusSet,
     mConStrStr, mAppendStrCh, mAppendStrStr, mAppendSeqElem,
-    mInRange, mInSet, mRepr,
-    mCopyStr, mCopyStrLast}
+    mInSet, mRepr}
 
 type
   PNode* = ref TNode

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -229,7 +229,7 @@ type
   TNodeKinds* = set[TNodeKind]
 
 type
-  TSymFlag* = enum    # 40 flags!
+  TSymFlag* = enum    # 41 flags!
     sfUsed,           # read access of sym (for warnings) or simply used
     sfExported,       # symbol is exported from module
     sfFromGeneric,    # symbol is instantiation of a generic; this is needed
@@ -238,6 +238,8 @@ type
     sfGlobal,         # symbol is at global scope
 
     sfForward,        # symbol is forward declared
+    sfWasForwarded,   # symbol had a forward declaration
+                      # (implies it's too dangerous to patch its type signature)
     sfImportc,        # symbol is external; imported
     sfExportc,        # symbol is exported (under a specified name)
     sfMangleCpp,      # mangle as cpp (combines with `sfExportc`)
@@ -847,7 +849,7 @@ type
     position*: int            # used for many different things:
                               # for enum fields its position;
                               # for fields its offset
-                              # for parameters its position
+                              # for parameters its position (starting with 0)
                               # for a conditional:
                               # 1 iff the symbol is defined, else 0
                               # (or not in symbol table)
@@ -1864,6 +1866,9 @@ proc isInlineIterator*(typ: PType): bool {.inline.} =
 
 proc isClosureIterator*(typ: PType): bool {.inline.} =
   typ.kind == tyProc and tfIterator in typ.flags and typ.callConv == ccClosure
+
+proc isClosure*(typ: PType): bool {.inline.} =
+  typ.kind == tyProc and typ.callConv == ccClosure
 
 proc isSinkParam*(s: PSym): bool {.inline.} =
   s.kind == skParam and (s.typ.kind == tySink or tfHasOwned in s.typ.flags)

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2040,14 +2040,14 @@ proc genDestroy(p: BProc; n: PNode) =
       initLocExpr(p, arg, a)
       linefmt(p, cpsStmts, "if ($1.p && !($1.p->cap & NIM_STRLIT_FLAG)) {$n" &
         " #deallocShared($1.p);$n" &
-        " $1.p = NIM_NIL; }$n",
+        " $1.p = NIM_NIL; $1.len = 0; }$n",
         [rdLoc(a)])
     of tySequence:
       var a: TLoc
       initLocExpr(p, arg, a)
       linefmt(p, cpsStmts, "if ($1.p && !($1.p->cap & NIM_STRLIT_FLAG)) {$n" &
         " #deallocShared($1.p);$n" &
-        " $1.p = NIM_NIL; }$n",
+        " $1.p = NIM_NIL; $1.len = 0; }$n",
         [rdLoc(a), getTypeDesc(p.module, t.lastSon)])
     else: discard "nothing to do"
   else:

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1412,7 +1412,7 @@ proc genAsgn(p: BProc, e: PNode, fastAsgn: bool) =
 proc genStmts(p: BProc, t: PNode) =
   var a: TLoc
 
-  let isPush = hintExtendedContext in p.config.notes
+  let isPush = p.config.hasHint(hintExtendedContext)
   if isPush: pushInfoContext(p.config, t.info)
   expr(p, t, a)
   if isPush: popInfoContext(p.config)

--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -10,7 +10,7 @@
 ## Helpers for binaries that use compiler passes, eg: nim, nimsuggest, nimfix
 
 import
-  options, idents, nimconf, scriptconfig, extccomp, commands, msgs,
+  options, idents, nimconf, extccomp, commands, msgs,
   lineinfos, modulegraphs, condsyms, os, pathutils
 
 from strutils import normalize
@@ -43,32 +43,13 @@ proc processCmdLineAndProjectPath*(self: NimProg, conf: ConfigRef) =
     conf.projectPath = AbsoluteDir canonicalizePath(conf, AbsoluteFile getCurrentDir())
 
 proc loadConfigsAndRunMainCommand*(self: NimProg, cache: IdentCache; conf: ConfigRef): bool =
-  loadConfigs(DefaultConfig, cache, conf) # load all config files
   if self.suggestMode:
     conf.command = "nimsuggest"
+  loadConfigs(DefaultConfig, cache, conf) # load all config files
 
-  template runNimScriptIfExists(path: AbsoluteFile) =
-    let p = path # eval once
-    if fileExists(p):
-      runNimScript(cache, p, freshDefines = false, conf)
-
-  # Caution: make sure this stays in sync with `loadConfigs`
-  if optSkipSystemConfigFile notin conf.globalOptions:
-    runNimScriptIfExists(getSystemConfigPath(conf, DefaultConfigNims))
-
-  if optSkipUserConfigFile notin conf.globalOptions:
-    runNimScriptIfExists(getUserConfigPath(DefaultConfigNims))
-
-  if optSkipParentConfigFiles notin conf.globalOptions:
-    for dir in parentDirs(conf.projectPath.string, fromRoot = true, inclusive = false):
-      runNimScriptIfExists(AbsoluteDir(dir) / DefaultConfigNims)
-
-  if optSkipProjConfigFile notin conf.globalOptions:
-    runNimScriptIfExists(conf.projectPath / DefaultConfigNims)
   block:
     let scriptFile = conf.projectFull.changeFileExt("nims")
     if not self.suggestMode:
-      runNimScriptIfExists(scriptFile)
       # 'nim foo.nims' means to just run the NimScript file and do nothing more:
       if fileExists(scriptFile) and scriptFile == conf.projectFull:
         if conf.command == "":
@@ -76,12 +57,6 @@ proc loadConfigsAndRunMainCommand*(self: NimProg, cache: IdentCache; conf: Confi
           return false
         elif conf.command.normalize == "e":
           return false
-    else:
-      if scriptFile != conf.projectFull:
-        runNimScriptIfExists(scriptFile)
-      else:
-        # 'nimsuggest foo.nims' means to just auto-complete the NimScript file
-        discard
 
   # now process command line arguments again, because some options in the
   # command line can overwrite the config file's settings

--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -27,9 +27,7 @@ proc initDefinesProg*(self: NimProg, conf: ConfigRef, name: string) =
   defineSymbol conf.symbols, name
 
 proc processCmdLineAndProjectPath*(self: NimProg, conf: ConfigRef) =
-  conf.isCmdLine = true
   self.processCmdLine(passCmd1, "", conf)
-  conf.isCmdLine = false
   if self.supportsStdinFile and conf.projectName == "-":
     handleStdinInput(conf)
   elif conf.projectName != "":

--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -27,7 +27,9 @@ proc initDefinesProg*(self: NimProg, conf: ConfigRef, name: string) =
   defineSymbol conf.symbols, name
 
 proc processCmdLineAndProjectPath*(self: NimProg, conf: ConfigRef) =
+  conf.isCmdLine = true
   self.processCmdLine(passCmd1, "", conf)
+  conf.isCmdLine = false
   if self.supportsStdinFile and conf.projectName == "-":
     handleStdinInput(conf)
   elif conf.projectName != "":

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -877,6 +877,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       localError(conf, info, "unknown Nim version; currently supported values are: {1.0}")
   of "benchmarkvm":
     processOnOffSwitchG(conf, {optBenchmarkVM}, arg, pass, info)
+  of "sinkinference":
+    processOnOffSwitch(conf, {optSinkInference}, arg, pass, info)
   of "": # comes from "-" in for example: `nim c -r -` (gets stripped from -)
     handleStdinInput(conf)
   else:

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -18,7 +18,8 @@ template bootSwitch(name, expr, userString) =
 
 bootSwitch(usedRelease, defined(release), "-d:release")
 bootSwitch(usedDanger, defined(danger), "-d:danger")
-bootSwitch(usedGnuReadline, defined(useLinenoise), "-d:useLinenoise")
+# `useLinenoise` deprecated in favor of `nimUseLinenoise`, kept for backward compatibility
+bootSwitch(useLinenoise, defined(nimUseLinenoise) or defined(useLinenoise), "-d:nimUseLinenoise")
 bootSwitch(usedBoehm, defined(boehmgc), "--gc:boehm")
 bootSwitch(usedMarkAndSweep, defined(gcmarkandsweep), "--gc:markAndSweep")
 bootSwitch(usedGenerational, defined(gcgenerational), "--gc:generational")
@@ -101,7 +102,7 @@ proc writeVersionInfo(conf: ConfigRef; pass: TCmdLinePass) =
       msgWriteln(conf, "git hash: " & gitHash, {msgStdout})
 
     msgWriteln(conf, "active boot switches:" & usedRelease & usedDanger &
-      usedTinyC & usedGnuReadline & usedNativeStacktrace &
+      usedTinyC & useLinenoise & usedNativeStacktrace &
       usedFFI & usedBoehm & usedMarkAndSweep & usedGenerational & usedGoGC & usedNoGC,
                {msgStdout})
     msgQuit(0)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -204,11 +204,17 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
     incl(conf.notes, n)
     incl(conf.mainPackageNotes, n)
     incl(conf.enableNotes, n)
+    if conf.isCmdLine:
+      incl(conf.cmdLineNotes, n)
+      excl(conf.cmdLineDisabledNotes, n)
   of "off":
     excl(conf.notes, n)
     excl(conf.mainPackageNotes, n)
     incl(conf.disableNotes, n)
     excl(conf.foreignPackageNotes, n)
+    if conf.isCmdLine:
+      incl(conf.cmdLineDisabledNotes, n)
+      excl(conf.cmdLineNotes, n)
   else: localError(conf, info, errOnOrOffExpectedButXFound % arg)
 
 proc processCompile(conf: ConfigRef; filename: string) =

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -204,7 +204,7 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
     incl(conf.notes, n)
     incl(conf.mainPackageNotes, n)
     incl(conf.enableNotes, n)
-    if conf.isCmdLine:
+    if pass == passCmd1:
       incl(conf.cmdLineNotes, n)
       excl(conf.cmdLineDisabledNotes, n)
   of "off":
@@ -212,7 +212,7 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
     excl(conf.mainPackageNotes, n)
     incl(conf.disableNotes, n)
     excl(conf.foreignPackageNotes, n)
-    if conf.isCmdLine:
+    if pass == passCmd1:
       incl(conf.cmdLineDisabledNotes, n)
       excl(conf.cmdLineNotes, n)
   else: localError(conf, info, errOnOrOffExpectedButXFound % arg)

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -111,3 +111,5 @@ proc initDefines*(symbols: StringTableRef) =
     # will report the right thing regardless of whether user adds
     # `-d:nimHasLibFFI` in his user config.
     defineSymbol("nimHasLibFFIEnabled")
+
+  defineSymbol("nimHasSinkInference")

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -104,6 +104,7 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasCursor")
   defineSymbol("nimHasExceptionsQuery")
   defineSymbol("nimHasIsNamedTuple")
+  defineSymbol("nimHashOrdinalFixed")
 
   when defined(nimHasLibFFI):
     # Renaming as we can't conflate input vs output define flags; e.g. this

--- a/compiler/dfa.nim
+++ b/compiler/dfa.nim
@@ -591,6 +591,8 @@ proc genUse(c: var Con; orig: PNode) =
     of PathKinds1:
       n = n[1]
     else: break
+    if n.kind in nkCallKinds:
+      gen(c, n)
   if n.kind == nkSym and n.sym.kind in InterestingSyms:
     c.code.add Instr(n: orig, kind: use)
 

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -191,10 +191,10 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
   initStrTable result.types
   result.onTestSnippet =
     proc (gen: var RstGenerator; filename, cmd: string; status: int; content: string) =
+      inc(gen.id)
       var d = TDocumentor(gen)
       var outp: AbsoluteFile
       if filename.len == 0:
-        inc(d.id)
         let nameOnly = splitFile(d.filename).name
         outp = getNimcacheDir(conf) / RelativeDir(nameOnly) /
                RelativeFile(nameOnly & "_snippet_" & $d.id & ".nim")

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1135,8 +1135,8 @@ proc generateIndex*(d: PDoc) =
 
 proc updateOutfile(d: PDoc, outfile: AbsoluteFile) =
   if d.module == nil or sfMainModule in d.module.flags: # nil for eg for commandRst2Html
-    if d.conf.outFile.isEmpty and not d.conf.outDir.isEmpty:
-      d.conf.outFile = outfile.relativeTo(d.conf.outDir)
+    if d.conf.outDir.isEmpty: d.conf.outDir = d.conf.projectPath
+    if d.conf.outFile.isEmpty: d.conf.outFile = outfile.relativeTo(d.conf.outDir)
 
 proc writeOutput*(d: PDoc, useWarning = false) =
   runAllExamples(d)

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -489,7 +489,7 @@ proc addExternalFileToLink*(conf: ConfigRef; filename: AbsoluteFile) =
   conf.externalToLink.insert(filename.string, 0)
 
 proc execWithEcho(conf: ConfigRef; cmd: string, msg = hintExecuting): int =
-  rawMessage(conf, msg, cmd)
+  rawMessage(conf, msg, if msg == hintLinking and not(optListCmd in conf.globalOptions or conf.verbosity > 1): "" else: cmd)
   result = execCmd(cmd)
 
 proc execExternalProgram*(conf: ConfigRef; cmd: string, msg = hintExecuting) =

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -715,7 +715,7 @@ proc compileCFiles(conf: ConfigRef; list: CfileList, script: var Rope, cmds: var
     if optCompileOnly notin conf.globalOptions:
       cmds.add(compileCmd)
       let (_, name, _) = splitFile(it.cname)
-      prettyCmds.add(if hintCC in conf.notes: "CC: " & demanglePackageName(name) else: "")
+      prettyCmds.add(if conf.hasHint(hintCC): "CC: " & demanglePackageName(name) else: "")
     if optGenScript in conf.globalOptions:
       script.add(compileCmd)
       script.add("\n")

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -149,7 +149,7 @@ compiler vcc:
     buildDll: " /LD",
     buildLib: "lib /OUT:$libfile $objfiles",
     linkerExe: "cl",
-    linkTmpl: "$options $builddll$vccplatform /Fe$exefile $objfiles $buildgui",
+    linkTmpl: "$builddll$vccplatform /Fe$exefile $objfiles $buildgui $options",
     includeCmd: " /I",
     linkDirCmd: " /LIBPATH:",
     linkLibCmd: " $1.lib",

--- a/compiler/forloops.nim
+++ b/compiler/forloops.nim
@@ -13,7 +13,7 @@ import ast, astalgo
 
 const
   someCmp = {mEqI, mEqF64, mEqEnum, mEqCh, mEqB, mEqRef, mEqProc,
-    mEqUntracedRef, mLeI, mLeF64, mLeU, mLeU64, mLeEnum,
+    mLeI, mLeF64, mLeU, mLeU64, mLeEnum,
     mLeCh, mLeB, mLePtr, mLtI, mLtF64, mLtU, mLtU64, mLtEnum,
     mLtCh, mLtB, mLtPtr}
 

--- a/compiler/guards.nim
+++ b/compiler/guards.nim
@@ -14,7 +14,7 @@ import ast, astalgo, msgs, magicsys, nimsets, trees, types, renderer, idents,
 
 const
   someEq = {mEqI, mEqF64, mEqEnum, mEqCh, mEqB, mEqRef, mEqProc,
-    mEqUntracedRef, mEqStr, mEqSet, mEqCString}
+    mEqStr, mEqSet, mEqCString}
 
   # set excluded here as the semantics are vastly different:
   someLe = {mLeI, mLeF64, mLeU, mLeU64, mLeEnum,
@@ -22,10 +22,9 @@ const
   someLt = {mLtI, mLtF64, mLtU, mLtU64, mLtEnum,
             mLtCh, mLtB, mLtPtr, mLtStr}
 
-  someLen = {mLengthOpenArray, mLengthStr, mLengthArray, mLengthSeq,
-             mXLenStr, mXLenSeq}
+  someLen = {mLengthOpenArray, mLengthStr, mLengthArray, mLengthSeq}
 
-  someIn = {mInRange, mInSet}
+  someIn = {mInSet}
 
   someHigh = {mHigh}
   # we don't list unsigned here because wrap around semantics suck for
@@ -258,7 +257,7 @@ proc canon*(n: PNode; o: Operators): PNode =
       result[i] = canon(n[i], o)
   elif n.kind == nkSym and n.sym.kind == skLet and
       n.sym.astdef.getMagic in (someEq + someAdd + someMul + someMin +
-      someMax + someHigh + {mUnaryLt} + someSub + someLen + someDiv):
+      someMax + someHigh + someSub + someLen + someDiv):
     result = n.sym.astdef.copyTree
   else:
     result = n
@@ -271,8 +270,6 @@ proc canon*(n: PNode; o: Operators): PNode =
   of someHigh:
     # high == len+(-1)
     result = o.opAdd.buildCall(o.opLen.buildCall(result[1]), minusOne())
-  of mUnaryLt:
-    result = buildCall(o.opAdd, result[1], minusOne())
   of someSub:
     # x - 4  -->  x + (-4)
     result = negate(result[1], result[2], result, o)

--- a/compiler/hlo.nim
+++ b/compiler/hlo.nim
@@ -17,7 +17,7 @@ proc evalPattern(c: PContext, n, orig: PNode): PNode =
   # awful to semcheck before macro invocation, so we don't and treat
   # templates and macros as immediate in this context.
   var rule: string
-  if optHints in c.config.options and hintPattern in c.config.notes:
+  if c.config.hasHint(hintPattern):
     rule = renderTree(n, {renderNoComments})
   let s = n[0].sym
   case s.kind
@@ -27,7 +27,7 @@ proc evalPattern(c: PContext, n, orig: PNode): PNode =
     result = semTemplateExpr(c, n, s, {efFromHlo})
   else:
     result = semDirectOp(c, n, {})
-  if optHints in c.config.options and hintPattern in c.config.notes:
+  if c.config.hasHint(hintPattern):
     message(c.config, orig.info, hintPattern, rule & " --> '" &
       renderTree(result, {renderNoComments}) & "'")
 

--- a/compiler/llstream.nim
+++ b/compiler/llstream.nim
@@ -12,8 +12,10 @@
 import
   pathutils
 
-template imp(x) = import x
-const hasRstdin = compiles(imp(rdstdin))
+# support `useGnuReadline`, `useLinenoise` for backwards compatibility
+const hasRstdin = (defined(nimUseLinenoise) or defined(useLinenoise) or defined(useGnuReadline)) and
+  not defined(windows)
+
 when hasRstdin: import rdstdin
 
 type

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -421,7 +421,7 @@ proc rawMessage*(conf: ConfigRef; msg: TMsgKind, args: openArray[string]) =
     if msg in conf.cmdLineDisabledNotes: return # eg: `--hints:conf:off` passed on cmdline
     # handle `--hints:off` (regardless of cmdline/cfg file)
     # handle `--hints:conf:on` on cmdline
-    if not conf.hasHint(msg) and not (optHints in conf.options and msg in conf.cmdLineNotes)): return
+    if not conf.hasHint(msg) and not (optHints in conf.options and msg in conf.cmdLineNotes): return
     title = HintTitle
     color = HintColor
     if msg != hintUserRaw: kind = HintsToStr[ord(msg) - ord(hintMin)]

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -418,7 +418,10 @@ proc rawMessage*(conf: ConfigRef; msg: TMsgKind, args: openArray[string]) =
     inc(conf.warnCounter)
   of hintMin..hintMax:
     sev = Severity.Hint
-    if not conf.hasHint(msg): return
+    if msg in conf.cmdLineDisabledNotes: return # eg: `--hints:conf:off` passed on cmdline
+    # handle `--hints:off` (regardless of cmdline/cfg file)
+    # handle `--hints:conf:on` on cmdline
+    if not conf.hasHint(msg) and not (optHints in conf.options and msg in conf.cmdLineNotes)): return
     title = HintTitle
     color = HintColor
     if msg != hintUserRaw: kind = HintsToStr[ord(msg) - ord(hintMin)]

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -418,10 +418,7 @@ proc rawMessage*(conf: ConfigRef; msg: TMsgKind, args: openArray[string]) =
     inc(conf.warnCounter)
   of hintMin..hintMax:
     sev = Severity.Hint
-    if msg in conf.cmdLineDisabledNotes: return # eg: `--hints:conf:off` passed on cmdline
-    # handle `--hints:off` (regardless of cmdline/cfg file)
-    # handle `--hints:conf:on` on cmdline
-    if not conf.hasHint(msg) and not (optHints in conf.options and msg in conf.cmdLineNotes): return
+    if not conf.hasHint(msg): return
     title = HintTitle
     color = HintColor
     if msg != hintUserRaw: kind = HintsToStr[ord(msg) - ord(hintMin)]

--- a/compiler/nim.cfg
+++ b/compiler/nim.cfg
@@ -1,7 +1,6 @@
 # Special configuration file for the Nim project
 
 hint[XDeclaredButNotUsed]:off
-hint[Link]:off
 
 define:booting
 define:nimcore

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -93,7 +93,7 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
 
   self.processCmdLineAndProjectPath(conf)
   if not self.loadConfigsAndRunMainCommand(cache, conf): return
-  if optHints in conf.options and hintGCStats in conf.notes: echo(GC_getStatistics())
+  if conf.hasHint(hintGCStats): echo(GC_getStatistics())
   #echo(GC_getStatistics())
   if conf.errorCounter != 0: return
   when hasTinyCBackend:

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -11,7 +11,7 @@
 
 import
   llstream, commands, os, strutils, msgs, lexer,
-  options, idents, wordrecg, strtabs, lineinfos, pathutils
+  options, idents, wordrecg, strtabs, lineinfos, pathutils, scriptconfig
 
 # ---------------- configuration file parser -----------------------------
 # we use Nim's scanner here to save space and work
@@ -248,16 +248,30 @@ proc loadConfigs*(cfg: RelativeFile; cache: IdentCache; conf: ConfigRef) =
     if readConfigFile(configPath, cache, conf):
       configFiles.add(configPath)
 
+  template runNimScriptIfExists(path: AbsoluteFile) =
+    let p = path # eval once
+    if fileExists(p):
+      runNimScript(cache, p, freshDefines = false, conf)
+
   if optSkipSystemConfigFile notin conf.globalOptions:
     readConfigFile(getSystemConfigPath(conf, cfg))
 
+    if cfg == DefaultConfig:
+      runNimScriptIfExists(getSystemConfigPath(conf, DefaultConfigNims))
+
   if optSkipUserConfigFile notin conf.globalOptions:
     readConfigFile(getUserConfigPath(cfg))
+
+    if cfg == DefaultConfig:
+      runNimScriptIfExists(getUserConfigPath(DefaultConfigNims))
 
   let pd = if not conf.projectPath.isEmpty: conf.projectPath else: AbsoluteDir(getCurrentDir())
   if optSkipParentConfigFiles notin conf.globalOptions:
     for dir in parentDirs(pd.string, fromRoot=true, inclusive=false):
       readConfigFile(AbsoluteDir(dir) / cfg)
+
+      if cfg == DefaultConfig:
+        runNimScriptIfExists(AbsoluteDir(dir) / DefaultConfigNims)
 
   if optSkipProjConfigFile notin conf.globalOptions:
     readConfigFile(pd / cfg)
@@ -269,6 +283,20 @@ proc loadConfigs*(cfg: RelativeFile; cache: IdentCache; conf: ConfigRef) =
         projectConfig = changeFileExt(conf.projectFull, "nim.cfg")
       readConfigFile(projectConfig)
 
+    if cfg == DefaultConfig:
+      runNimScriptIfExists(pd / DefaultConfigNims)
+
   for filename in configFiles:
     # delayed to here so that `hintConf` is honored
     rawMessage(conf, hintConf, filename.string)
+
+  block:
+    let scriptFile = conf.projectFull.changeFileExt("nims")
+    if conf.command != "nimsuggest":
+      runNimScriptIfExists(scriptFile)
+    else:
+      if scriptFile != conf.projectFull:
+        runNimScriptIfExists(scriptFile)
+      else:
+        # 'nimsuggest foo.nims' means to just auto-complete the NimScript file
+        discard

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -251,6 +251,7 @@ proc loadConfigs*(cfg: RelativeFile; cache: IdentCache; conf: ConfigRef) =
   template runNimScriptIfExists(path: AbsoluteFile) =
     let p = path # eval once
     if fileExists(p):
+      configFiles.add(p)
       runNimScript(cache, p, freshDefines = false, conf)
 
   if optSkipSystemConfigFile notin conf.globalOptions:

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -39,7 +39,8 @@ type                          # please make sure we have under 32 options
     optMemTracker,
     optLaxStrings,
     optNilSeqs,
-    optOldAst
+    optOldAst,
+    optSinkInference          # 'sink T' inference
 
   TOptions* = set[TOption]
   TGlobalOption* = enum       # **keep binary compatible**
@@ -200,7 +201,7 @@ type
                           ## the incremental compilation mechanisms
                           ## (+) means "part of the dependency"
     target*: Target       # (+)
-    linesCompiled*: int  # all lines that have been compiled
+    linesCompiled*: int   # all lines that have been compiled
     options*: TOptions    # (+)
     globalOptions*: TGlobalOptions # (+)
     macrosToExpand*: StringTableRef
@@ -315,7 +316,7 @@ const
   DefaultOptions* = {optObjCheck, optFieldCheck, optRangeCheck,
     optBoundsCheck, optOverflowCheck, optAssert, optWarns, optRefCheck,
     optHints, optStackTrace, optLineTrace,
-    optTrMacros, optNilCheck, optStyleCheck}
+    optTrMacros, optNilCheck, optStyleCheck, optSinkInference}
   DefaultGlobalOptions* = {optThreadAnalysis,
     optExcessiveStackTrace, optListFullPaths}
 

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -287,6 +287,12 @@ type
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
 
+proc hasHint*(conf: ConfigRef, note: TNoteKind): bool =
+  optHints in conf.options and note in conf.notes
+
+proc hasWarn*(conf: ConfigRef, note: TNoteKind): bool =
+  optWarns in conf.options and note in conf.notes
+
 proc hcrOn*(conf: ConfigRef): bool = return optHotCodeReloading in conf.globalOptions
 
 template depConfigFields*(fn) {.dirty.} =

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -226,13 +226,11 @@ type
     ideCmd*: IdeCmd
     oldNewlines*: bool
     cCompiler*: TSystemCC
-    enableNotes*: TNoteKinds
-    disableNotes*: TNoteKinds
+    modifiedyNotes*: TNoteKinds # notes that have been set/unset from either cmdline/configs
+    cmdlineNotes*: TNoteKinds # notes that have been set/unset from cmdline
     foreignPackageNotes*: TNoteKinds
-    notes*: TNoteKinds
+    notes*: TNoteKinds # notes after resolving all logic(defaults, verbosity)/cmdline/configs
     mainPackageNotes*: TNoteKinds
-    cmdLineNotes*: TNoteKinds
-    cmdLineDisabledNotes*: TNoteKinds
     mainPackageId*: int
     errorCounter*: int
     hintCounter*: int
@@ -288,6 +286,10 @@ type
     structuredErrorHook*: proc (config: ConfigRef; info: TLineInfo; msg: string;
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
+
+proc setNote*(conf: ConfigRef, note: TNoteKind, enabled = true) =
+  if note notin conf.cmdlineNotes:
+    if enabled: incl(conf.notes, note) else: excl(conf.notes, note)
 
 proc hasHint*(conf: ConfigRef, note: TNoteKind): bool =
   optHints in conf.options and note in conf.notes

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -288,7 +288,6 @@ type
     structuredErrorHook*: proc (config: ConfigRef; info: TLineInfo; msg: string;
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
-    isCmdLine*: bool # whether we are currently processing cmdline args, not cfg files
 
 proc hasHint*(conf: ConfigRef, note: TNoteKind): bool =
   optHints in conf.options and note in conf.notes
@@ -394,7 +393,6 @@ proc newConfigRef*(): ConfigRef =
     arguments: "",
     suggestMaxResults: 10_000,
     maxLoopIterationsVM: 10_000_000,
-    isCmdLine: false,
   )
   setTargetFromSystem(result.target)
   # enable colors by default on terminals

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -231,6 +231,8 @@ type
     foreignPackageNotes*: TNoteKinds
     notes*: TNoteKinds
     mainPackageNotes*: TNoteKinds
+    cmdLineNotes*: TNoteKinds
+    cmdLineDisabledNotes*: TNoteKinds
     mainPackageId*: int
     errorCounter*: int
     hintCounter*: int
@@ -286,6 +288,7 @@ type
     structuredErrorHook*: proc (config: ConfigRef; info: TLineInfo; msg: string;
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
+    isCmdLine*: bool # whether we are currently processing cmdline args, not cfg files
 
 proc hasHint*(conf: ConfigRef, note: TNoteKind): bool =
   optHints in conf.options and note in conf.notes
@@ -391,6 +394,7 @@ proc newConfigRef*(): ConfigRef =
     arguments: "",
     suggestMaxResults: 10_000,
     maxLoopIterationsVM: 10_000_000,
+    isCmdLine: false,
   )
   setTargetFromSystem(result.target)
   # enable colors by default on terminals

--- a/compiler/passaux.nim
+++ b/compiler/passaux.nim
@@ -28,8 +28,8 @@ proc verboseProcess(context: PPassContext, n: PNode): PNode =
   let v = VerboseRef(context)
   if v.config.verbosity == 3:
     # system.nim deactivates all hints, for verbosity:3 we want the processing
-    # messages nonetheless, so we activate them again unconditionally:
-    incl(v.config.notes, hintProcessing)
+    # messages nonetheless, so we activate them again (but honor cmdlineNotes)
+    v.config.setNote(hintProcessing)
     message(v.config, n.info, hintProcessing, $idgen.gFrontEndId)
 
 const verbosePass* = makePass(open = verboseOpen, process = verboseProcess)

--- a/compiler/pathutils.nim
+++ b/compiler/pathutils.nim
@@ -102,6 +102,8 @@ when true:
 
 when isMainModule:
   doAssert AbsoluteDir"/Users/me///" / RelativeFile"z.nim" == AbsoluteFile"/Users/me/z.nim"
+  doAssert AbsoluteDir"/Users/me" / RelativeFile"../z.nim" == AbsoluteFile"/Users/z.nim"
+  doAssert AbsoluteDir"/Users/me/" / RelativeFile"../z.nim" == AbsoluteFile"/Users/z.nim"
   doAssert relativePath("/foo/bar.nim", "/foo/", '/') == "bar.nim"
   doAssert $RelativeDir"foo/bar" == "foo/bar"
   doAssert RelativeDir"foo/bar" == RelativeDir"foo/bar"

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -23,7 +23,7 @@ const
     wExportNims, wExtern, wDeprecated, wNodecl, wError, wUsed, wAlign}
     ## common pragmas for declarations, to a good approximation
   procPragmas* = declPragmas + {FirstCallConv..LastCallConv,
-    wMagic, wNoSideEffect, wSideEffect, wNoreturn, wDynlib, wHeader,
+    wMagic, wNoSideEffect, wSideEffect, wNoreturn, wNosinks, wDynlib, wHeader,
     wCompilerProc, wNonReloadable, wCore, wProcVar, wVarargs, wCompileTime, wMerge,
     wBorrow, wImportCompilerProc, wThread,
     wAsmNoStackFrame, wDiscardable, wNoInit, wCodegenDecl,
@@ -53,7 +53,7 @@ const
     wLinearScanEnd, wPatterns, wTrMacros, wEffects, wNoForward, wReorder, wComputedGoto,
     wInjectStmt, wExperimental, wThis, wUsed}
   lambdaPragmas* = declPragmas + {FirstCallConv..LastCallConv,
-    wNoSideEffect, wSideEffect, wNoreturn, wDynlib, wHeader,
+    wNoSideEffect, wSideEffect, wNoreturn, wNosinks, wDynlib, wHeader,
     wThread, wAsmNoStackFrame,
     wRaises, wLocks, wTags, wGcSafe, wCodegenDecl} - {wExportNims, wError, wUsed}  # why exclude these?
   typePragmas* = declPragmas + {wMagic, wAcyclic,
@@ -357,6 +357,7 @@ proc pragmaToOptions(w: TSpecialWord): TOptions {.inline.} =
   of wByRef: {optByRef}
   of wImplicitStatic: {optImplicitStatic}
   of wPatterns, wTrMacros: {optTrMacros}
+  of wSinkInference: {optSinkInference}
   else: {}
 
 proc processExperimental(c: PContext; n: PNode) =
@@ -889,6 +890,9 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wNoDestroy:
         noVal(c, it)
         incl(sym.flags, sfGeneratedOp)
+      of wNosinks:
+        noVal(c, it)
+        incl(sym.flags, sfWasForwarded)
       of wDynlib:
         processDynLib(c, it, sym)
       of wCompilerProc, wCore:

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -328,6 +328,7 @@ proc processNote(c: PContext, n: PNode) =
     n[1] = x
     if x.kind == nkIntLit and x.intVal != 0: incl(c.config.notes, nk)
     else: excl(c.config.notes, nk)
+    # checkme: honor cmdlineNotes with: c.setNote(nk, x.kind == nkIntLit and x.intVal != 0)
   else:
     invalidPragma(c, n)
 

--- a/compiler/rodimpl.nim
+++ b/compiler/rodimpl.nim
@@ -667,7 +667,7 @@ proc loadType(g; id: int; info: TLineInfo): PType =
       rawAddSon(result, nil)
     else:
       let d = decodeVInt(b.s, b.pos)
-      rawAddSon(result, loadType(g, d, info))
+      result.sons.add loadType(g, d, info)
 
 proc decodeLib(g; b; info: TLineInfo): PLib =
   result = nil
@@ -719,10 +719,8 @@ proc loadSymFromBlob(g; b; info: TLineInfo): PSym =
   else:
     internalError(g.config, info, "decodeSym: no ident")
   #echo "decoding: {", ident.s
-  new(result)
-  result.id = id
-  result.kind = k
-  result.name = ident         # read the rest of the symbol description:
+  result = PSym(id: id, kind: k, name: ident)
+  # read the rest of the symbol description:
   g.incr.r.syms.add(result.id, result)
   if b.s[b.pos] == '^':
     inc(b.pos)

--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -199,7 +199,6 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
 
 proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
                    freshDefines=true; conf: ConfigRef) =
-  rawMessage(conf, hintConf, scriptName.string)
   let oldSymbolFiles = conf.symbolFiles
   conf.symbolFiles = disabledSf
 
@@ -224,7 +223,7 @@ proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
   incl(m.flags, sfMainModule)
   graph.vm = setupVM(m, cache, scriptName.string, graph)
 
-  graph.compileSystemModule() # TODO: see why this unsets hintConf in conf.notes
+  graph.compileSystemModule()
   discard graph.processModule(m, llStreamOpen(scriptName, fmRead))
 
   # watch out, "newruntime" can be set within NimScript itself and then we need

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -395,7 +395,7 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
   if c.config.evalTemplateCounter > evalTemplateLimit:
     globalError(c.config, s.info, "template instantiation too nested")
   c.friendModules.add(s.owner.getModule)
-
+  idSynchronizationPoint(5000)
   result = macroResult
   excl(result.flags, nfSem)
   #resetSemFlag n

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -181,7 +181,7 @@ proc endsInNoReturn(n: PNode): bool =
   var it = n
   while it.kind in {nkStmtList, nkStmtListExpr} and it.len > 0:
     it = it.lastSon
-  result = it.kind == nkRaiseStmt or
+  result = it.kind in nkLastBlockStmts or
     it.kind in nkCallKinds and it[0].kind == nkSym and sfNoReturn in it[0].sym.flags
 
 proc commonType*(x: PType, y: PNode): PType =

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -990,7 +990,7 @@ proc buildEchoStmt(c: PContext, n: PNode): PNode =
   result = semExpr(c, result)
 
 proc semExprNoType(c: PContext, n: PNode): PNode =
-  let isPush = hintExtendedContext in c.config.notes
+  let isPush = c.config.hasHint(hintExtendedContext)
   if isPush: pushInfoContext(c.config, n.info)
   result = semExpr(c, n, {efWantStmt})
   discardCheck(c, result, {})

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -140,7 +140,7 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
 
   if operand.kind == tyGenericParam or (traitCall.len > 2 and operand2.kind == tyGenericParam):
     return traitCall  ## too early to evaluate
-    
+
   let s = trait.sym.name.s
   case s
   of "or", "|":
@@ -479,8 +479,6 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
     result.typ = n[1].typ
   of mDotDot:
     result = n
-  of mRoof:
-    localError(c.config, n.info, "builtin roof operator is not supported anymore")
   of mPlugin:
     let plugin = getPlugin(c.cache, n[0].sym)
     if plugin.isNil:

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -16,6 +16,7 @@ when defined(useDfa):
   import dfa
 
 import liftdestructors
+include sinkparameter_inference
 
 #[ Second semantic checking pass over the AST. Necessary because the old
    way had some inherent problems. Performs:
@@ -774,6 +775,10 @@ proc track(tracked: PEffects, n: PNode) =
 
     for i in 0..<n.safeLen:
       track(tracked, n[i])
+    if op != nil and op.kind == tyProc:
+      for i in 1..<min(n.safeLen, op.len):
+        if op[i].kind == tySink:
+          checkForSink(tracked.config, tracked.owner, n[i])
   of nkDotExpr:
     guardDotAccess(tracked, n)
     for i in 0..<n.len: track(tracked, n[i])
@@ -793,6 +798,7 @@ proc track(tracked: PEffects, n: PNode) =
     when false: cstringCheck(tracked, n)
     if tracked.owner.kind != skMacro:
       createTypeBoundOps(tracked, n[0].typ, n.info)
+    checkForSink(tracked.config, tracked.owner, n[1])
   of nkVarSection, nkLetSection:
     for child in n:
       let last = lastSon(child)
@@ -871,6 +877,11 @@ proc track(tracked: PEffects, n: PNode) =
         addDiscriminantFact(tracked.guards, x)
       if tracked.owner.kind != skMacro:
         createTypeBoundOps(tracked, x[1].typ, n.info)
+
+      if x.kind == nkExprColonExpr:
+        checkForSink(tracked.config, tracked.owner, x[1])
+      else:
+        checkForSink(tracked.config, tracked.owner, x)
     setLen(tracked.guards.s, oldFacts)
     if tracked.owner.kind != skMacro:
       # XXX n.typ can be nil in runnableExamples, we need to do something about it.
@@ -882,6 +893,7 @@ proc track(tracked: PEffects, n: PNode) =
       track(tracked, n[i])
       if tracked.owner.kind != skMacro:
         createTypeBoundOps(tracked, n[i].typ, n.info)
+      checkForSink(tracked.config, tracked.owner, n[i])
   of nkPragmaBlock:
     let pragmaList = n[0]
     let oldLocked = tracked.locked.len
@@ -927,7 +939,9 @@ proc track(tracked: PEffects, n: PNode) =
         createTypeBoundOps(tracked, n.typ, n.info)
         createTypeBoundOps(tracked, n[0].typ, n[0].info)
   of nkBracket:
-    for i in 0..<n.safeLen: track(tracked, n[i])
+    for i in 0..<n.safeLen:
+      track(tracked, n[i])
+      checkForSink(tracked.config, tracked.owner, n[i])
     if tracked.owner.kind != skMacro:
       createTypeBoundOps(tracked, n.typ, n.info)
   else:
@@ -1035,8 +1049,10 @@ proc trackProc*(c: PContext; s: PSym, body: PNode) =
     let params = s.typ.n
     for i in 1..<params.len:
       let param = params[i].sym
-      if isSinkTypeForParam(param.typ):
-        createTypeBoundOps(t, param.typ, param.info)
+      let typ = param.typ
+      if isSinkTypeForParam(typ) or
+          (t.config.selectedGC in {gcArc, gcOrc} and isClosure(typ.skipTypes(abstractInst))):
+        createTypeBoundOps(t, typ, param.info)
 
   if not isEmptyType(s.typ[0]) and
       ({tfNeedsInit, tfNotNil} * s.typ[0].flags != {} or

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1884,6 +1884,7 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
     if sfForward notin proto.flags and proto.magic == mNone:
       wrongRedefinition(c, n.info, proto.name.s, proto.info)
     excl(proto.flags, sfForward)
+    incl(proto.flags, sfWasForwarded)
     closeScope(c)         # close scope with wrong parameter symbols
     openScope(c)          # open scope for old (correct) parameter symbols
     if proto.ast[genericParamsPos].kind != nkEmpty:
@@ -1962,6 +1963,7 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
     if proto != nil: localError(c.config, n.info, errImplOfXexpected % proto.name.s)
     if {sfImportc, sfBorrow, sfError} * s.flags == {} and s.magic == mNone:
       incl(s.flags, sfForward)
+      incl(s.flags, sfWasForwarded)
     elif sfBorrow in s.flags: semBorrow(c, n, s)
   sideEffectsCheck(c, s)
   closeScope(c)           # close scope for parameters

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1298,6 +1298,8 @@ proc typeSectionFinalPass(c: PContext, n: PNode) =
         checkConstructedType(c.config, s.info, s.typ)
         if s.typ.kind in {tyObject, tyTuple} and not s.typ.n.isNil:
           checkForMetaFields(c, s.typ.n)
+          # fix bug #5170: ensure locally scoped object types get a unique name:
+          if s.typ.kind == tyObject and not isTopLevel(c): incl(s.flags, sfGenSym)
   #instAllTypeBoundOp(c, n.info)
 
 

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -120,7 +120,7 @@ const
 proc implicitlyDiscardable(n: PNode): bool =
   var n = n
   while n.kind in skipForDiscardable: n = n.lastSon
-  result = n.kind == nkRaiseStmt or
+  result = n.kind in nkLastBlockStmts or
            (isCallExpr(n) and n[0].kind == nkSym and
            sfDiscardable in n[0].sym.flags)
 
@@ -2162,9 +2162,6 @@ proc inferConceptStaticParam(c: PContext, inferred, n: PNode) =
   typ.n = res
 
 proc semStmtList(c: PContext, n: PNode, flags: TExprFlags): PNode =
-  # these must be last statements in a block:
-  const
-    LastBlockStmts = {nkRaiseStmt, nkReturnStmt, nkBreakStmt, nkContinueStmt}
   result = n
   result.transitionSonsKind(nkStmtList)
   var voidContext = false
@@ -2209,7 +2206,7 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags): PNode =
     else:
       n.typ = n[i].typ
       if not isEmptyType(n.typ): n.transitionSonsKind(nkStmtListExpr)
-    if n[i].kind in LastBlockStmts or
+    if n[i].kind in nkLastBlockStmts or
         n[i].kind in nkCallKinds and n[i][0].kind == nkSym and
         sfNoReturn in n[i][0].sym.flags:
       for j in i + 1..<n.len:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1898,10 +1898,6 @@ proc processMagicType(c: PContext, m: PSym) =
     setMagicIntegral(c.config, m, tyCString, c.config.target.ptrSize)
     rawAddSon(m.typ, getSysType(c.graph, m.info, tyChar))
   of mPointer: setMagicIntegral(c.config, m, tyPointer, c.config.target.ptrSize)
-  of mEmptySet:
-    setMagicIntegral(c.config, m, tySet, 1)
-    rawAddSon(m.typ, newTypeS(tyEmpty, c))
-  of mIntSetBaseType: setMagicIntegral(c.config, m, tyRange, c.config.target.intSize)
   of mNil: setMagicType(c.config, m, tyNil, c.config.target.ptrSize)
   of mExpr:
     if m.name.s == "auto":
@@ -1937,8 +1933,6 @@ proc processMagicType(c: PContext, m: PSym) =
       incl m.typ.flags, tfHasAsgn
     assert c.graph.sysTypes[tySequence] == nil
     c.graph.sysTypes[tySequence] = m.typ
-  of mOpt:
-    setMagicType(c.config, m, tyOpt, szUncomputedSize)
   of mOrdinal:
     setMagicIntegral(c.config, m, tyOrdinal, szUncomputedSize)
     rawAddSon(m.typ, newTypeS(tyNone, c))

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -832,9 +832,6 @@ proc inferStaticParam*(c: var TCandidate, lhs: PNode, rhs: BiggestInt): bool =
   #
   if lhs.kind in nkCallKinds and lhs[0].kind == nkSym:
     case lhs[0].sym.magic
-    of mUnaryLt:
-      return inferStaticParam(c, lhs[1], rhs + 1)
-
     of mAddI, mAddU, mInc, mSucc:
       if lhs[1].kind == nkIntLit:
         return inferStaticParam(c, lhs[2], rhs - lhs[1].intVal)

--- a/compiler/sinkparameter_inference.nim
+++ b/compiler/sinkparameter_inference.nim
@@ -1,0 +1,70 @@
+#
+#
+#           The Nim Compiler
+#        (c) Copyright 2020 Andreas Rumpf
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+proc checkForSink*(config: ConfigRef; owner: PSym; arg: PNode) =
+  #[ Patterns we seek to detect:
+
+    someLocation = p # ---> p: sink T
+    passToSink(p)    # p: sink
+    ObjConstr(fieldName: p)
+    [p, q] # array construction
+
+    # Open question:
+    var local = p # sink parameter?
+    passToSink(local)
+  ]#
+  if optSinkInference notin config.options: return
+  case arg.kind
+  of nkSym:
+    if arg.sym.kind == skParam and
+        arg.sym.owner == owner and
+        owner.typ != nil and owner.typ.kind == tyProc and
+        arg.sym.typ.hasDestructor and
+        arg.sym.typ.kind notin {tyVar, tySink, tyOwned}:
+      # Watch out: cannot do this inference for procs with forward
+      # declarations.
+      if sfWasForwarded notin owner.flags:
+        let argType = arg.sym.typ
+
+        let sinkType = newType(tySink, owner)
+        sinkType.size = argType.size
+        sinkType.align = argType.align
+        sinkType.paddingAtEnd = argType.paddingAtEnd
+        sinkType.add argType
+
+        arg.sym.typ = sinkType
+        owner.typ[arg.sym.position+1] = sinkType
+
+        #message(config, arg.info, warnUser,
+        #  ("turned '$1' to a sink parameter") % [$arg])
+        #echo config $ arg.info, " turned into a sink parameter ", arg.sym.name.s
+      elif sfWasForwarded notin arg.sym.flags:
+        # we only report every potential 'sink' parameter only once:
+        incl arg.sym.flags, sfWasForwarded
+        message(config, arg.info, hintPerformance,
+          ("could not turn '$1' to a sink parameter " &
+          "because '$2' was forward declared") % [arg.sym.name.s, owner.name.s])
+      #echo config $ arg.info, " candidate for a sink parameter here"
+  of nkStmtList, nkStmtListExpr, nkBlockStmt, nkBlockExpr:
+    if not isEmptyType(arg.typ):
+      checkForSink(config, owner, arg.lastSon)
+  of nkIfStmt, nkIfExpr, nkWhen:
+    for branch in arg:
+      let value = branch.lastSon
+      if not isEmptyType(value.typ):
+        checkForSink(config, owner, value)
+  of nkCaseStmt:
+    for i in 1..<arg.len:
+      let value = arg[i].lastSon
+      if not isEmptyType(value.typ):
+        checkForSink(config, owner, value)
+  of nkTryStmt:
+    checkForSink(config, owner, arg[0])
+  else:
+    discard "nothing to do"

--- a/compiler/syntaxes.nim
+++ b/compiler/syntaxes.nim
@@ -120,7 +120,7 @@ proc applyFilter(p: var TParsers, n: PNode, filename: AbsoluteFile,
     result = filterReplace(p.config, stdin, filename, n)
   if f != filtNone:
     assert p.config != nil
-    if hintCodeBegin in p.config.notes:
+    if p.config.hasHint(hintCodeBegin):
       rawMessage(p.config, hintCodeBegin, [])
       msgWriteln(p.config, result.s)
       rawMessage(p.config, hintCodeEnd, [])

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -580,11 +580,11 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcCastIntToFloat32:
       let rb = instr.regB
       ensureKind(rkFloat)
-      regs[ra].floatVal = cast[float32](int32(regs[rb].intVal))
+      regs[ra].floatVal = cast[float32](regs[rb].intVal)
     of opcCastIntToFloat64:
       let rb = instr.regB
       ensureKind(rkFloat)
-      regs[ra].floatVal = cast[float64](int64(regs[rb].intVal))
+      regs[ra].floatVal = cast[float64](regs[rb].intVal)
 
     of opcCastPtrToInt: # RENAME opcCastPtrOrRefToInt
       decodeBImm(rkInt)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1089,11 +1089,6 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       createSet(regs[ra])
       move(regs[ra].node.sons,
            nimsets.diffSets(c.config, regs[rb].node, regs[rc].node).sons)
-    of opcSymdiffSet:
-      decodeBC(rkNode)
-      createSet(regs[ra])
-      move(regs[ra].node.sons,
-           nimsets.symdiffSets(c.config, regs[rb].node, regs[rc].node).sons)
     of opcConcatStr:
       decodeBC(rkNode)
       createStr regs[ra]

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -95,7 +95,7 @@ type
     opcEqRef, opcEqNimNode, opcSameNodeType,
     opcXor, opcNot, opcUnaryMinusInt, opcUnaryMinusFloat, opcBitnotInt,
     opcEqStr, opcLeStr, opcLtStr, opcEqSet, opcLeSet, opcLtSet,
-    opcMulSet, opcPlusSet, opcMinusSet, opcSymdiffSet, opcConcatStr,
+    opcMulSet, opcPlusSet, opcMinusSet, opcConcatStr,
     opcContainsSet, opcRepr, opcSetLenStr, opcSetLenSeq,
     opcIsNil, opcOf, opcIs,
     opcSubStr, opcParseFloat, opcConv, opcCast,

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -973,11 +973,6 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
   case m
   of mAnd: c.genAndOr(n, opcFJmp, dest)
   of mOr:  c.genAndOr(n, opcTJmp, dest)
-  of mUnaryLt:
-    let tmp = c.genx(n[1])
-    if dest < 0: dest = c.getTemp(n.typ)
-    c.gABI(n, opcSubImmInt, dest, tmp, 1)
-    c.freeTemp(tmp)
   of mPred, mSubI:
     c.genAddSubInt(n, dest, opcSubInt)
   of mSucc, mAddI:
@@ -1020,9 +1015,9 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
     c.gABC(n, opcNewStr, dest, tmp)
     c.freeTemp(tmp)
     # XXX buggy
-  of mLengthOpenArray, mLengthArray, mLengthSeq, mXLenSeq:
+  of mLengthOpenArray, mLengthArray, mLengthSeq:
     genUnaryABI(c, n, dest, opcLenSeq)
-  of mLengthStr, mXLenStr:
+  of mLengthStr:
     genUnaryABI(c, n, dest, opcLenStr)
   of mIncl, mExcl:
     unused(c, n, dest)
@@ -1078,7 +1073,7 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mLtF64: genBinaryABC(c, n, dest, opcLtFloat)
   of mLePtr, mLeU, mLeU64: genBinaryABC(c, n, dest, opcLeu)
   of mLtPtr, mLtU, mLtU64: genBinaryABC(c, n, dest, opcLtu)
-  of mEqProc, mEqRef, mEqUntracedRef:
+  of mEqProc, mEqRef:
     genBinaryABC(c, n, dest, opcEqRef)
   of mXor: genBinaryABC(c, n, dest, opcXor)
   of mNot: genUnaryABC(c, n, dest, opcNot)
@@ -1105,7 +1100,6 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mMulSet: genBinarySet(c, n, dest, opcMulSet)
   of mPlusSet: genBinarySet(c, n, dest, opcPlusSet)
   of mMinusSet: genBinarySet(c, n, dest, opcMinusSet)
-  of mSymDiffSet: genBinarySet(c, n, dest, opcSymdiffSet)
   of mConStrStr: genVarargsABC(c, n, dest, opcConcatStr)
   of mInSet: genBinarySet(c, n, dest, opcContainsSet)
   of mRepr: genUnaryABC(c, n, dest, opcRepr)
@@ -1126,29 +1120,6 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
     unused(c, n, dest)
     c.gen(lowerSwap(c.graph, n, if c.prc == nil: c.module else: c.prc.sym))
   of mIsNil: genUnaryABC(c, n, dest, opcIsNil)
-  of mCopyStr:
-    if dest < 0: dest = c.getTemp(n.typ)
-    var
-      tmp1 = c.genx(n[1])
-      tmp2 = c.genx(n[2])
-      tmp3 = c.getTemp(n[2].typ)
-    c.gABC(n, opcLenStr, tmp3, tmp1)
-    c.gABC(n, opcSubStr, dest, tmp1, tmp2)
-    c.gABC(n, opcSubStr, tmp3)
-    c.freeTemp(tmp1)
-    c.freeTemp(tmp2)
-    c.freeTemp(tmp3)
-  of mCopyStrLast:
-    if dest < 0: dest = c.getTemp(n.typ)
-    var
-      tmp1 = c.genx(n[1])
-      tmp2 = c.genx(n[2])
-      tmp3 = c.genx(n[3])
-    c.gABC(n, opcSubStr, dest, tmp1, tmp2)
-    c.gABC(n, opcSubStr, tmp3)
-    c.freeTemp(tmp1)
-    c.freeTemp(tmp2)
-    c.freeTemp(tmp3)
   of mParseBiggestFloat:
     if dest < 0: dest = c.getTemp(n.typ)
     var d2: TRegister

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -2094,12 +2094,10 @@ proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
     genWhile(c, n)
   of nkBlockExpr, nkBlockStmt: genBlock(c, n, dest)
   of nkReturnStmt:
-    unused(c, n, dest)
     genReturn(c, n)
   of nkRaiseStmt:
     genRaise(c, n)
   of nkBreakStmt:
-    unused(c, n, dest)
     genBreak(c, n)
   of nkTryStmt, nkHiddenTryStmt: genTry(c, n, dest)
   of nkStmtList:

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -102,6 +102,35 @@ proc staticWalkDirImpl(path: string, relative: bool): PNode =
     result.add newTree(nkTupleConstr, newIntNode(nkIntLit, k.ord),
                               newStrNode(nkStrLit, f))
 
+from std / compilesettings import SingleValueSetting, MultipleValueSetting
+
+proc querySettingImpl(a: VmArgs, conf: ConfigRef, switch: BiggestInt): string =
+  case SingleValueSetting(switch)
+  of arguments: result = conf.arguments
+  of outFile: result = conf.outFile.string
+  of outDir: result = conf.outDir.string
+  of nimcacheDir: result = conf.nimcacheDir.string
+  of projectName: result = conf.projectName
+  of projectPath: result = conf.projectPath.string
+  of projectFull: result = conf.projectFull.string
+  of command: result = conf.command
+  of commandLine: result = conf.commandLine
+  of linkOptions: result = conf.linkOptions
+  of compileOptions: result = conf.compileOptions
+  of ccompilerPath: result = conf.cCompilerPath
+
+proc querySettingSeqImpl(a: VmArgs, conf: ConfigRef, switch: BiggestInt): seq[string] =
+  template copySeq(field: untyped): untyped =
+    for i in field: result.add i.string
+
+  case MultipleValueSetting(switch)
+  of nimblePaths: copySeq(conf.nimblePaths)
+  of searchPaths: copySeq(conf.searchPaths)
+  of lazyPaths: copySeq(conf.lazyPaths)
+  of commandArgs: result = conf.commandArgs
+  of cincludes: copySeq(conf.cIncludes)
+  of clibs: copySeq(conf.cLibs)
+
 proc registerAdditionalOps*(c: PCtx) =
   proc gorgeExWrapper(a: VmArgs) =
     let (s, e) = opGorge(getString(a, 0), getString(a, 1), getString(a, 2),
@@ -152,6 +181,10 @@ proc registerAdditionalOps*(c: PCtx) =
     systemop getCurrentException
     registerCallback c, "stdlib.*.staticWalkDir", proc (a: VmArgs) {.nimcall.} =
       setResult(a, staticWalkDirImpl(getString(a, 0), getBool(a, 1)))
+    registerCallback c, "stdlib.compilesettings.querySetting", proc (a: VmArgs) {.nimcall.} =
+      setResult(a, querySettingImpl(a, c.config, getInt(a, 0)))
+    registerCallback c, "stdlib.compilesettings.querySettingSeq", proc (a: VmArgs) {.nimcall.} =
+      setResult(a, querySettingSeqImpl(a, c.config, getInt(a, 0)))
 
     if defined(nimsuggest) or c.config.cmd == cmdCheck:
       discard "don't run staticExec for 'nim suggest'"

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -42,7 +42,7 @@ type
     wImportCompilerProc,
     wImportc, wImportJs, wExportc, wExportCpp, wExportNims, wIncompleteStruct, wRequiresInit,
     wAlign, wNodecl, wPure, wSideEffect, wHeader,
-    wNoSideEffect, wGcSafe, wNoreturn, wMerge, wLib, wDynlib,
+    wNoSideEffect, wGcSafe, wNoreturn, wNosinks, wMerge, wLib, wDynlib,
     wCompilerProc, wCore, wProcVar, wBase, wUsed,
     wFatal, wError, wWarning, wHint, wLine, wPush, wPop, wDefine, wUndef,
     wLineDir, wStackTrace, wLineTrace, wLink, wCompile,
@@ -52,7 +52,7 @@ type
     wBoundChecks, wOverflowChecks, wNilChecks,
     wFloatChecks, wNanChecks, wInfChecks, wStyleChecks,
     wNonReloadable, wExecuteOnReload,
-    wAssertions, wPatterns, wTrMacros, wWarnings,
+    wAssertions, wPatterns, wTrMacros, wSinkInference, wWarnings,
     wHints, wOptimization, wRaises, wWrites, wReads, wSize, wEffects, wTags,
     wDeadCodeElimUnused,  # deprecated, dead code elim always happens
     wSafecode, wPackage, wNoForward, wReorder, wNoRewrite, wNoDestroy,
@@ -128,7 +128,7 @@ const
     "importcompilerproc", "importc", "importjs", "exportc", "exportcpp", "exportnims",
     "incompletestruct",
     "requiresinit", "align", "nodecl", "pure", "sideeffect",
-    "header", "nosideeffect", "gcsafe", "noreturn", "merge", "lib", "dynlib",
+    "header", "nosideeffect", "gcsafe", "noreturn", "nosinks", "merge", "lib", "dynlib",
     "compilerproc", "core", "procvar", "base", "used",
     "fatal", "error", "warning", "hint", "line",
     "push", "pop", "define", "undef", "linedir", "stacktrace", "linetrace",
@@ -140,7 +140,7 @@ const
     "floatchecks", "nanchecks", "infchecks", "stylechecks",
     "nonreloadable", "executeonreload",
 
-    "assertions", "patterns", "trmacros", "warnings", "hints",
+    "assertions", "patterns", "trmacros", "sinkinference", "warnings", "hints",
     "optimization", "raises", "writes", "reads", "size", "effects", "tags",
     "deadcodeelim",  # deprecated, dead code elim always happens
     "safecode", "package", "noforward", "reorder", "norewrite", "nodestroy",

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -49,7 +49,7 @@ Advanced options:
   --import:PATH             add an automatically imported module
   --include:PATH            add an automatically included module
   --nimcache:PATH           set the path used for generated files
-                            see also https://nim-lang.org/docs/nimc.html#compiler-usage-generated-c-code-directory 
+                            see also https://nim-lang.org/docs/nimc.html#compiler-usage-generated-c-code-directory
   -c, --compileOnly:on|off  compile Nim files only; do not assemble or link
   --noLinking:on|off        compile Nim and generated files but do not link
   --noMain:on|off           do not generate a main procedure
@@ -145,3 +145,4 @@ Advanced options:
                             works better with `--stackTrace:on`
                             see also https://nim-lang.github.io/Nim/estp.html
   --benchmarkVM:on|off      enable benchmarking of VM code with cpuTime()
+  --sinkInference:on|off    en-/disable sink parameter inference (default: on)

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -125,8 +125,8 @@ Advanced options:
                             dynlib: "liblua.so.3"
   --dynlibOverrideAll
                             disables the effects of the dynlib pragma
-  --listCmd                 list the compilation commands; can be combined with:
-                            --hint:exec:on and --hint:link:on
+  --listCmd                 list the compilation commands; can be combined with
+                            `--hint:exec:on` and `--hint:link:on`
   --asm                     produce assembler code
   --parallelBuild:0|1|...   perform a parallel build
                             value = number of processors (0 for auto-detect)

--- a/doc/destructors.rst
+++ b/doc/destructors.rst
@@ -256,6 +256,23 @@ An implementation is allowed, but not required to implement even more move
 optimizations (and the current implementation does not).
 
 
+Sink parameter inference
+========================
+
+The current implementation does a limited form of sink parameter
+inference. The `.nosinks`:idx: pragma can be used to disable this inference
+for a single routine:
+
+.. code-block:: nim
+
+  proc addX(x: T; child: T) {.nosinks.} =
+    x.s.add child
+
+To disable it for a section of code, one can
+use `{.push sinkInference: off.}`...`{.pop.}`.
+
+The details of the inference algorithm are currently undocumented.
+
 
 Rewrite rules
 =============

--- a/doc/koch.rst
+++ b/doc/koch.rst
@@ -35,7 +35,7 @@ options:
   By default a debug version is created, passing this option will
   force a release build, which is much faster and should be preferred
   unless you are debugging the compiler.
--d:useLinenoise
+-d:nimUseLinenoise
   Use the linenoise library for interactive mode (not needed on Windows).
 
 After compilation is finished you will hopefully end up with the nim

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -5645,6 +5645,8 @@ It is not checked that the ``except`` list is really exported from the module.
 This feature allows to compile against an older version of the module that
 does not export these identifiers.
 
+The ``import`` statement is only allowed at the top level.
+
 
 Include statement
 ~~~~~~~~~~~~~~~~~
@@ -5655,6 +5657,18 @@ statement is useful to split up a large module into several files:
 .. code-block:: nim
   include fileA, fileB, fileC
 
+The ``include`` statement can be used outside of the top level, as such:
+
+.. code-block:: nim
+  # Module A
+  echo "Hello World!"
+
+.. code-block:: nim
+  # Module B
+  proc main() =
+    include A
+  
+  main() # => Hello World!
 
 
 Module names in imports

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -559,7 +559,7 @@ following characters::
 defined here.)
 
 These keywords are also operators:
-``and or not xor shl shr div mod in notin is isnot of``.
+``and or not xor shl shr div mod in notin is isnot of as``.
 
 `.`:tok: `=`:tok:, `:`:tok:, `::`:tok: are not available as general operators; they
 are used for other notational purposes.
@@ -632,21 +632,21 @@ has the second lowest precedence.
 
 Otherwise precedence is determined by the first character.
 
-================  ===============================================  ==================  ===============
-Precedence level    Operators                                      First character     Terminal symbol
-================  ===============================================  ==================  ===============
- 10 (highest)                                                      ``$  ^``            OP10
-  9               ``*    /    div   mod   shl  shr  %``            ``*  %  \  /``      OP9
-  8               ``+    -``                                       ``+  -  ~  |``      OP8
-  7               ``&``                                            ``&``               OP7
-  6               ``..``                                           ``.``               OP6
-  5               ``==  <= < >= > !=  in notin is isnot not of``   ``=  <  >  !``      OP5
-  4               ``and``                                                              OP4
-  3               ``or xor``                                                           OP3
-  2                                                                ``@  :  ?``         OP2
-  1               *assignment operator* (like ``+=``, ``*=``)                          OP1
-  0 (lowest)      *arrow like operator* (like ``->``, ``=>``)                          OP0
-================  ===============================================  ==================  ===============
+================  ==================================================  ==================  ===============
+Precedence level    Operators                                         First character     Terminal symbol
+================  ==================================================  ==================  ===============
+ 10 (highest)                                                         ``$  ^``            OP10
+  9               ``*    /    div   mod   shl  shr  %``               ``*  %  \  /``      OP9
+  8               ``+    -``                                          ``+  -  ~  |``      OP8
+  7               ``&``                                               ``&``               OP7
+  6               ``..``                                              ``.``               OP6
+  5               ``==  <= < >= > !=  in notin is isnot not of as``   ``=  <  >  !``      OP5
+  4               ``and``                                                                 OP4
+  3               ``or xor``                                                              OP3
+  2                                                                   ``@  :  ?``         OP2
+  1               *assignment operator* (like ``+=``, ``*=``)                             OP1
+  0 (lowest)      *arrow like operator* (like ``->``, ``=>``)                             OP0
+================  ==================================================  ==================  ===============
 
 
 Whether an operator is used a prefix operator is also affected by preceding

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -528,7 +528,7 @@ for further information.
 
   The Nim compiler supports an interactive mode. This is also known as
   a `REPL`:idx: (*read eval print loop*). If Nim has been built with the
-  ``-d:useGnuReadline`` switch, it uses the GNU readline library for terminal
+  ``-d:nimUseLinenoise`` switch, it uses the GNU readline library for terminal
   input management. To start Nim in interactive mode use the command
   ``nim secret``. To quit use the ``quit()`` command. To determine whether an input
   line is an incomplete statement to be continued these rules are used:

--- a/doc/tut1.rst
+++ b/doc/tut1.rst
@@ -743,13 +743,19 @@ Overloaded procedures
 Nim provides the ability to overload procedures similar to C++:
 
 .. code-block:: nim
-  proc toString(x: int): string = ...
-  proc toString(x: bool): string =
-    if x: result = "true"
-    else: result = "false"
+  proc toString(x: int): string =
+    result =
+      if x < 0: "negative"
+      elif x > 0: "positive"
+      else: "zero"
 
-  echo toString(13)   # calls the toString(x: int) proc
-  echo toString(true) # calls the toString(x: bool) proc
+  proc toString(x: bool): string =
+    result =
+      if x: "yep"
+      else: "nope"
+
+  assert toString(13) == "positive" # calls the toString(x: int) proc
+  assert toString(true) == "yep"    # calls the toString(x: bool) proc
 
 (Note that ``toString`` is usually the `$ <dollars.html>`_ operator in
 Nim.) The compiler chooses the most appropriate proc for the ``toString``

--- a/koch.nim
+++ b/koch.nim
@@ -472,9 +472,14 @@ proc xtemp(cmd: string) =
   finally:
     copyExe(d / "bin" / "nim_backup".exe, d / "bin" / "nim".exe)
 
+proc hostInfo(): string =
+  "hostOS: $1, hostCPU: $2, int: $3, float: $4, cpuEndian: $5, cwd: $6" %
+    [hostOS, hostCPU, $int.sizeof, $float.sizeof, $cpuEndian, getCurrentDir()]
+
 proc runCI(cmd: string) =
   doAssert cmd.len == 0, cmd # avoid silently ignoring
   echo "runCI:", cmd
+  echo hostInfo()
   # note(@araq): Do not replace these commands with direct calls (eg boot())
   # as that would weaken our testing efforts.
   when defined(posix): # appveyor (on windows) didn't run this

--- a/koch.nim
+++ b/koch.nim
@@ -55,8 +55,8 @@ Possible Commands:
   nimble                   builds the Nimble tool
 Boot options:
   -d:release               produce a release version of the compiler
-  -d:useLinenoise          use the linenoise library for interactive mode
-                           (not needed on Windows)
+  -d:nimUseLinenoise       use the linenoise library for interactive mode
+                           `nim secret` (not needed on Windows)
   -d:leanCompiler          produce a compiler without JS codegen or
                            documentation generator in order to use less RAM
                            for bootstrapping

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1471,7 +1471,7 @@ macro expandMacros*(body: typed): untyped =
   ## For instance,
   ##
   ## .. code-block:: nim
-  ##   import future, macros
+  ##   import sugar, macros
   ##
   ##   let
   ##     x = 10

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1458,7 +1458,7 @@ proc boolVal*(n: NimNode): bool {.compileTime, noSideEffect.} =
   else: n == bindSym"true" # hacky solution for now
 
 when defined(nimMacrosGetNodeId):
-  proc nodeID*(n: NimNode): int {.magic: NodeId.}
+  proc nodeID*(n: NimNode): int {.magic: "NodeId".}
     ## Returns the id of ``n``, when the compiler has been compiled
     ## with the flag ``-d:useNodeids``, otherwise returns ``-1``. This
     ## proc is for the purpose to debug the compiler only.

--- a/lib/pure/collections/intsets.nim
+++ b/lib/pure/collections/intsets.nim
@@ -330,6 +330,15 @@ proc excl*(s: var IntSet, other: IntSet) =
 
   for item in other: excl(s, item)
 
+proc len*(s: IntSet): int {.inline.} =
+  ## Returns the number of elements in `s`.
+  if s.elems < s.a.len:
+    result = s.elems
+  else:
+    result = 0
+    for _ in s:
+      inc(result)
+
 proc missingOrExcl*(s: var IntSet, key: int): bool =
   ## Excludes `key` in the set `s` and tells if `key` was already missing from `s`.
   ##
@@ -348,9 +357,9 @@ proc missingOrExcl*(s: var IntSet, key: int): bool =
     assert a.missingOrExcl(5) == false
     assert a.missingOrExcl(5) == true
 
-  var count = s.elems
+  var count = s.len
   exclImpl(s, key)
-  result = count == s.elems
+  result = count == s.len
 
 proc clear*(result: var IntSet) =
   ## Clears the IntSet back to an empty state.
@@ -513,15 +522,6 @@ proc disjoint*(s1, s2: IntSet): bool =
     if contains(s2, item):
       return false
   return true
-
-proc len*(s: IntSet): int {.inline.} =
-  ## Returns the number of elements in `s`.
-  if s.elems < s.a.len:
-    result = s.elems
-  else:
-    result = 0
-    for _ in s:
-      inc(result)
 
 proc card*(s: IntSet): int {.inline.} =
   ## Alias for `len() <#len,IntSet>`_.

--- a/lib/pure/collections/setimpl.nim
+++ b/lib/pure/collections/setimpl.nim
@@ -38,7 +38,7 @@ proc enlarge[A](s: var HashSet[A]) =
   newSeq(n, len(s.data) * growthFactor)
   swap(s.data, n) # n is now old seq
   for i in countup(0, high(n)):
-    if isFilled(n[i].hcode):
+    if isFilledAndValid(n[i].hcode):
       var j = -1 - rawGetKnownHC(s, n[i].key, n[i].hcode)
       rawInsert(s, s.data, n[i].key, n[i].hcode, j)
 
@@ -112,7 +112,7 @@ proc enlarge[A](s: var OrderedSet[A]) =
   swap(s.data, n)
   while h >= 0:
     var nxt = n[h].next
-    if isFilled(n[h].hcode):
+    if isFilled(n[h].hcode): # should be isFilledAndValid once tombstones are used
       var j = -1 - rawGetKnownHC(s, n[h].key, n[h].hcode)
       rawInsert(s, s.data, n[h].key, n[h].hcode, j)
     h = nxt
@@ -130,7 +130,7 @@ proc exclImpl[A](s: var OrderedSet[A], key: A): bool {.inline.} =
   result = true
   while h >= 0:
     var nxt = n[h].next
-    if isFilled(n[h].hcode):
+    if isFilled(n[h].hcode): # should be isFilledAndValid once tombstones are used
       if n[h].hcode == hc and n[h].key == key:
         dec s.counter
         result = false

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -206,6 +206,11 @@ proc del*[A, B](t: var SharedTable[A, B], key: A) =
   withLock t:
     delImpl()
 
+proc len*[A, B](t: var SharedTable[A, B]): int =
+  ## number of elements in `t`
+  withLock t:
+    result = t.counter
+
 proc init*[A, B](t: var SharedTable[A, B], initialSize = 64) =
   ## creates a new hash table that is empty.
   ##

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -107,13 +107,23 @@ template clearImpl() {.dirty.} =
     t.data[i].val = default(type(t.data[i].val))
   t.counter = 0
 
+template ctAnd(a, b): bool =
+  # pending https://github.com/nim-lang/Nim/issues/13502
+  when a:
+    when b: true
+    else: false
+  else: false
+
 template initImpl(result: typed, size: int) =
-  assert isPowerOfTwo(size)
-  result.counter = 0
-  newSeq(result.data, size)
-  when compiles(result.first):
-    result.first = -1
-    result.last = -1
+  when ctAnd(declared(SharedTable), type(result) is SharedTable):
+    init(result, size)
+  else:
+    assert isPowerOfTwo(size)
+    result.counter = 0
+    newSeq(result.data, size)
+    when compiles(result.first):
+      result.first = -1
+      result.last = -1
 
 template insertImpl() = # for CountTable
   checkIfInitialized()

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -1118,7 +1118,7 @@ iterator pairs*[A, B](t: TableRef[A, B]): (A, B) =
   ##   # value: [1, 5, 7, 9]
   let L = len(t)
   for h in 0 .. high(t.data):
-    if isFilled(t.data[h].hcode):
+    if isFilledAndValid(t.data[h].hcode):
       yield (t.data[h].key, t.data[h].val)
       assert(len(t) == L, "the length of the table changed while iterating over it")
 
@@ -1140,7 +1140,7 @@ iterator mpairs*[A, B](t: TableRef[A, B]): (A, var B) =
 
   let L = len(t)
   for h in 0 .. high(t.data):
-    if isFilled(t.data[h].hcode):
+    if isFilledAndValid(t.data[h].hcode):
       yield (t.data[h].key, t.data[h].val)
       assert(len(t) == L, "the length of the table changed while iterating over it")
 
@@ -1161,7 +1161,7 @@ iterator keys*[A, B](t: TableRef[A, B]): A =
 
   let L = len(t)
   for h in 0 .. high(t.data):
-    if isFilled(t.data[h].hcode):
+    if isFilledAndValid(t.data[h].hcode):
       yield t.data[h].key
       assert(len(t) == L, "the length of the table changed while iterating over it")
 
@@ -1182,7 +1182,7 @@ iterator values*[A, B](t: TableRef[A, B]): B =
 
   let L = len(t)
   for h in 0 .. high(t.data):
-    if isFilled(t.data[h].hcode):
+    if isFilledAndValid(t.data[h].hcode):
       yield t.data[h].val
       assert(len(t) == L, "the length of the table changed while iterating over it")
 
@@ -1203,7 +1203,7 @@ iterator mvalues*[A, B](t: TableRef[A, B]): var B =
 
   let L = len(t)
   for h in 0 .. high(t.data):
-    if isFilled(t.data[h].hcode):
+    if isFilledAndValid(t.data[h].hcode):
       yield t.data[h].val
       assert(len(t) == L, "the length of the table changed while iterating over it")
 
@@ -1282,6 +1282,10 @@ template forAllOrderedPairs(yieldStmt: untyped) {.dirty.} =
     var h = t.first
     while h >= 0:
       var nxt = t.data[h].next
+       # For OrderedTable/OrderedTableRef, isFilled is ok because `del` is O(n)
+       # and doesn't create tombsones, but if it does start using tombstones,
+       # carefully replace `isFilled` by `isFilledAndValid` as appropriate for these
+       # table types only, ditto with `OrderedSet`.
       if isFilled(t.data[h].hcode):
         yieldStmt
       h = nxt

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -112,7 +112,7 @@ proc hash*[T: proc](x: T): Hash {.inline.} =
   else:
     result = hash(pointer(x))
 
-proc hash*(x: int|int64|uint|uint64|char|Ordinal): Hash {.inline.} =
+proc hash*[T: Ordinal](x: T): Hash {.inline.} =
   ## Efficient hashing of integers.
   cast[Hash](ord(x))
 

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -97,6 +97,7 @@ const
   Http504* = HttpCode(504)
   Http505* = HttpCode(505)
 
+const httpNewLine* = "\c\L"
 const headerLimit* = 10_000
 
 proc newHttpHeaders*(): HttpHeaders =

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -105,11 +105,15 @@ proc newHttpHeaders*(): HttpHeaders =
 
 proc newHttpHeaders*(keyValuePairs:
     openArray[tuple[key: string, val: string]]): HttpHeaders =
-  var pairs: seq[tuple[key: string, val: seq[string]]] = @[]
-  for pair in keyValuePairs:
-    pairs.add((pair.key.toLowerAscii(), @[pair.val]))
   new result
-  result.table = newTable[string, seq[string]](pairs)
+  result.table = newTable[string, seq[string]]()
+  for pair in keyValuePairs:
+    let key = pair.key.toLowerAscii()
+    if key in result.table:
+      result.table[key].add(pair.val)
+    else:
+      result.table[key] = @[pair.val]
+
 
 proc `$`*(headers: HttpHeaders): string =
   return $headers.table

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -523,8 +523,10 @@ proc getOrDefault*(node: JsonNode, key: string): JsonNode =
   if not isNil(node) and node.kind == JObject:
     result = node.fields.getOrDefault(key)
 
-template simpleGetOrDefault*{`{}`(node, [key])}(node: JsonNode,
-    key: string): JsonNode = node.getOrDefault(key)
+proc `{}`*(node: JsonNode, key: string): JsonNode =
+  ## Gets a field from a `node`. If `node` is nil or not an object or
+  ## value at `key` does not exist, returns nil
+  node.getOrDefault(key)
 
 proc `{}=`*(node: JsonNode, keys: varargs[string], value: JsonNode) =
   ## Traverses the node and tries to set the value at the given location

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -127,6 +127,7 @@ template endsWith(a: string, b: set[char]): bool =
 
 proc joinPathImpl(result: var string, state: var int, tail: string) =
   let trailingSep = tail.endsWith({DirSep, AltSep}) or tail.len == 0 and result.endsWith({DirSep, AltSep})
+  normalizePathEnd(result, trailingSep=false)
   addNormalizePath(tail, result, state, DirSep)
   normalizePathEnd(result, trailingSep=trailingSep)
 

--- a/lib/pure/pathnorm.nim
+++ b/lib/pure/pathnorm.nim
@@ -76,6 +76,11 @@ proc addNormalizePath*(x: string; result: var string; state: var int;
       if (state shr 1) >= 1:
         var d = result.len
         # f/..
+        # We could handle stripping trailing sep here: foo// => foo like this:
+        # while (d-1) > (state and 1) and result[d-1] in {DirSep, AltSep}: dec d
+        # but right now we instead handle it inside os.joinPath
+
+        # strip path component: foo/bar => foo
         while (d-1) > (state and 1) and result[d-1] notin {DirSep, AltSep}:
           dec d
         if d > 0:

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -191,7 +191,7 @@ proc isUpperAscii*(c: char): bool {.noSideEffect, procvar,
   return c in {'A'..'Z'}
 
 
-proc toLowerAscii*(c: char): char {.inline, noSideEffect, procvar,
+proc toLowerAscii*(c: char): char {.noSideEffect, procvar,
   rtl, extern: "nsuToLowerAsciiChar".} =
   ## Returns the lower case version of character ``c``.
   ##
@@ -229,7 +229,7 @@ proc toLowerAscii*(s: string): string {.inline, noSideEffect, procvar,
     doAssert toLowerAscii("FooBar!") == "foobar!"
   toImpl toLowerAscii
 
-proc toUpperAscii*(c: char): char {.inline, noSideEffect, procvar,
+proc toUpperAscii*(c: char): char {.noSideEffect, procvar,
   rtl, extern: "nsuToUpperAsciiChar".} =
   ## Converts character `c` into upper case.
   ##

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2862,7 +2862,7 @@ proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl,
 
 
 since (1, 1):
-  template toLowerAscii*(c: var char, linearScanEnd: static[char] = ' ') =
+  template toLowerAscii*(c: var char, linearScanEnd: static[char]) =
     ## Returns the lower case version of character ``c``.
     ##
     ## This works only for the letters ``A-Z``. See `unicode.toLower
@@ -2892,7 +2892,7 @@ since (1, 1):
       toLowerAscii(character, linearScanEnd = 'f')
       doAssert character == 'f'
       var chara = 'A'
-      toLowerAscii(chara)
+      toLowerAscii(chara, linearScanEnd = ' ')
       doAssert chara == 'a'
     c = case c
       of 'A':
@@ -2976,7 +2976,7 @@ since (1, 1):
       else: c
 
 
-  template toUpperAscii*(c: var char, linearScanEnd: static[char] = ' ') =
+  template toUpperAscii*(c: var char, linearScanEnd: static[char]) =
     ## Converts character `c` into upper case.
     ##
     ## This works only for the letters ``A-Z``.  See `unicode.toUpper
@@ -3007,7 +3007,7 @@ since (1, 1):
       toUpperAscii(character, linearScanEnd = 'f')
       doAssert character == 'F'
       var chara = 'z'
-      toUpperAscii(chara)
+      toUpperAscii(chara, linearScanEnd = ' ')
       doAssert chara == 'Z'
     c = case c
       of 'a':
@@ -3091,7 +3091,7 @@ since (1, 1):
       else: c
 
 
-  func toLowerAscii*(s: var string, linearScanEnd: static[char] = ' ') {.inline.} =
+  func toLowerAscii*(s: var string, linearScanEnd: static[char]) {.inline.} =
     ## Converts string `s` into lower case.
     ##
     ## This works only for the letters ``A-Z``. See `unicode.toLower
@@ -3117,7 +3117,7 @@ since (1, 1):
       toLowerAscii(stringy, linearScanEnd = 'f')
       doAssert stringy == "abcdef"
       var strng = "NIM"
-      toLowerAscii(strng)
+      toLowerAscii(strng, linearScanEnd = 'n')
       doAssert strng == "nim"
     var i = 0
     for c in mitems(s):
@@ -3126,7 +3126,7 @@ since (1, 1):
       inc i
 
 
-  func toUpperAscii*(s: var string, linearScanEnd: static[char] = ' ') {.inline.} =
+  func toUpperAscii*(s: var string, linearScanEnd: static[char]) {.inline.} =
     ## Converts string `s` into upper case.
     ##
     ## This works only for the letters ``A-Z``.  See `unicode.toUpper
@@ -3154,7 +3154,7 @@ since (1, 1):
       toUpperAscii(stringo, linearScanEnd = 'f')
       doAssert stringo == "ABCDEF"
       var strng = "nim"
-      toUpperAscii(strng)
+      toUpperAscii(strng, linearScanEnd = 'n')
       doAssert strng == "NIM"
     var i = 0
     for c in mitems(s):
@@ -3163,7 +3163,7 @@ since (1, 1):
       inc i
 
 
-  func capitalizeAscii*(s: var string, linearScanEnd: static[char] = ' ') {.inline.} =
+  func capitalizeAscii*(s: var string, linearScanEnd: static[char]) {.inline.} =
     ## Converts the first character of string `s` into upper case.
     ##
     ## This works only for the letters ``A-Z``.
@@ -3190,7 +3190,7 @@ since (1, 1):
       capitalizeAscii(stringu, linearScanEnd = 'f')
       doAssert stringu == "Foo"
       var stringx = "-bar"
-      capitalizeAscii(stringx, linearScanEnd = 'f')
+      capitalizeAscii(stringx, linearScanEnd = 'r')
       doAssert stringx == "-bar"
     toUpperAscii(s[0], linearScanEnd)
 

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -191,7 +191,7 @@ proc isUpperAscii*(c: char): bool {.noSideEffect, procvar,
   return c in {'A'..'Z'}
 
 
-proc toLowerAscii*(c: char): char {.noSideEffect, procvar,
+proc toLowerAscii*(c: char): char {.inline, noSideEffect, procvar,
   rtl, extern: "nsuToLowerAsciiChar".} =
   ## Returns the lower case version of character ``c``.
   ##
@@ -215,7 +215,7 @@ template toImpl(call) =
   for i in 0..len(s) - 1:
     result[i] = call(s[i])
 
-proc toLowerAscii*(s: string): string {.noSideEffect, procvar,
+proc toLowerAscii*(s: string): string {.inline, noSideEffect, procvar,
   rtl, extern: "nsuToLowerAsciiStr".} =
   ## Converts string `s` into lower case.
   ##
@@ -229,7 +229,7 @@ proc toLowerAscii*(s: string): string {.noSideEffect, procvar,
     doAssert toLowerAscii("FooBar!") == "foobar!"
   toImpl toLowerAscii
 
-proc toUpperAscii*(c: char): char {.noSideEffect, procvar,
+proc toUpperAscii*(c: char): char {.inline, noSideEffect, procvar,
   rtl, extern: "nsuToUpperAsciiChar".} =
   ## Converts character `c` into upper case.
   ##
@@ -249,7 +249,7 @@ proc toUpperAscii*(c: char): char {.noSideEffect, procvar,
   else:
     result = c
 
-proc toUpperAscii*(s: string): string {.noSideEffect, procvar,
+proc toUpperAscii*(s: string): string {.inline, noSideEffect, procvar,
   rtl, extern: "nsuToUpperAsciiStr".} =
   ## Converts string `s` into upper case.
   ##

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2862,337 +2862,163 @@ proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl,
 
 
 since (1, 1):
-  template toLowerAscii*(c: var char, linearScanEnd: static[char]) =
+  template toLowerAsciiInPlace*(c: var char) =
     ## Returns the lower case version of character ``c``.
     ##
     ## This works only for the letters ``A-Z``. See `unicode.toLower
     ## <unicode.html#toLower,Rune>`_ for a version that works for any Unicode
     ## character.
     ##
-    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
-    ## if the char is on the range ``'a'..'z'`` then it will add a
-    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
-    ## at compile-time at that char position, reducing the case switch linear scan.
-    ##
-    ## Example: Imagine that you are working with Hexadecimal strings,
-    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
-    ## This is an optional compile-time optimization, is disabled by default.
-    ##
-    ## .. code-block:: nim
-    ##   var character = 'F'  ## Hexadecimal
-    ##   toLowerAscii(character, linearScanEnd = 'f')
-    ##   doAssert character == 'f'
-    ##
     ## See also:
     ## * `isLowerAscii proc<#isLowerAscii,char>`_
     ## * `toLowerAscii proc<#toLowerAscii,string>`_ for converting a string
-    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
     runnableExamples:
       var character = 'F'
-      toLowerAscii(character, linearScanEnd = 'f')
+      toLowerAsciiInPlace(character)
       doAssert character == 'f'
       var chara = 'A'
-      toLowerAscii(chara, linearScanEnd = ' ')
+      toLowerAsciiInPlace(chara)
       doAssert chara == 'a'
     c = case c
-      of 'A':
-        when linearScanEnd == 'a': {.linearScanEnd.}
-        'a'
-      of 'B':
-        when linearScanEnd == 'b': {.linearScanEnd.}
-        'b'
-      of 'C':
-        when linearScanEnd == 'c': {.linearScanEnd.}
-        'c'
-      of 'D':
-        when linearScanEnd == 'd': {.linearScanEnd.}
-        'd'
-      of 'E':
-        when linearScanEnd == 'e': {.linearScanEnd.}
-        'e'
-      of 'F':
-        when linearScanEnd == 'f': {.linearScanEnd.}
-        'f'
-      of 'G':
-        when linearScanEnd == 'g': {.linearScanEnd.}
-        'g'
-      of 'H':
-        when linearScanEnd == 'h': {.linearScanEnd.}
-        'h'
-      of 'I':
-        when linearScanEnd == 'i': {.linearScanEnd.}
-        'i'
-      of 'J':
-        when linearScanEnd == 'j': {.linearScanEnd.}
-        'j'
-      of 'K':
-        when linearScanEnd == 'k': {.linearScanEnd.}
-        'k'
-      of 'L':
-        when linearScanEnd == 'l': {.linearScanEnd.}
-        'l'
-      of 'M':
-        when linearScanEnd == 'm': {.linearScanEnd.}
-        'm'
-      of 'N':
-        when linearScanEnd == 'n': {.linearScanEnd.}
-        'n'
-      of 'O':
-        when linearScanEnd == 'o': {.linearScanEnd.}
-        'o'
-      of 'P':
-        when linearScanEnd == 'p': {.linearScanEnd.}
-        'p'
-      of 'Q':
-        when linearScanEnd == 'q': {.linearScanEnd.}
-        'q'
-      of 'R':
-        when linearScanEnd == 'r': {.linearScanEnd.}
-        'r'
-      of 'S':
-        when linearScanEnd == 's': {.linearScanEnd.}
-        's'
-      of 'T':
-        when linearScanEnd == 't': {.linearScanEnd.}
-        't'
-      of 'U':
-        when linearScanEnd == 'u': {.linearScanEnd.}
-        'u'
-      of 'V':
-        when linearScanEnd == 'v': {.linearScanEnd.}
-        'v'
-      of 'W':
-        when linearScanEnd == 'w': {.linearScanEnd.}
-        'w'
-      of 'X':
-        when linearScanEnd == 'x': {.linearScanEnd.}
-        'x'
-      of 'Y':
-        when linearScanEnd == 'y': {.linearScanEnd.}
-        'y'
-      of 'Z':
-        when linearScanEnd == 'z': {.linearScanEnd.}
-        'z'
+      of 'A': 'a'
+      of 'B': 'b'
+      of 'C': 'c'
+      of 'D': 'd'
+      of 'E': 'e'
+      of 'F': 'f'
+      of 'G': 'g'
+      of 'H': 'h'
+      of 'I': 'i'
+      of 'J': 'j'
+      of 'K': 'k'
+      of 'L': 'l'
+      of 'M': 'm'
+      of 'N': 'n'
+      of 'O': 'o'
+      of 'P': 'p'
+      of 'Q': 'q'
+      of 'R': 'r'
+      of 'S': 's'
+      of 'T': 't'
+      of 'U': 'u'
+      of 'V': 'v'
+      of 'W': 'w'
+      of 'X': 'x'
+      of 'Y': 'y'
+      of 'Z': 'z'
       else: c
 
 
-  template toUpperAscii*(c: var char, linearScanEnd: static[char]) =
+  template toUpperAsciiInPlace*(c: var char) =
     ## Converts character `c` into upper case.
     ##
     ## This works only for the letters ``A-Z``.  See `unicode.toUpper
     ## <unicode.html#toUpper,Rune>`_ for a version that works for any Unicode
     ## character.
     ##
-    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
-    ## if the char is on the range ``'a'..'z'`` then it will add a
-    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
-    ## at compile-time at that char position, reducing the case switch linear scan.
-    ##
-    ## Example: Imagine that you are working with Hexadecimal strings,
-    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
-    ## This is an optional compile-time optimization, is disabled by default.
-    ##
-    ## .. code-block:: nim
-    ##   var character = 'F'  ## Hexadecimal
-    ##   toLowerAscii(character, linearScanEnd = 'f')
-    ##   doAssert character == 'f'
-    ##
     ## See also:
     ## * `isLowerAscii proc<#isLowerAscii,char>`_
     ## * `toUpperAscii proc<#toUpperAscii,string>`_ for converting a string
     ## * `capitalizeAscii proc<#capitalizeAscii,string>`_
-    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
     runnableExamples:
       var character = 'f'
-      toUpperAscii(character, linearScanEnd = 'f')
+      toUpperAsciiInPlace(character)
       doAssert character == 'F'
       var chara = 'z'
-      toUpperAscii(chara, linearScanEnd = ' ')
+      toUpperAsciiInPlace(chara)
       doAssert chara == 'Z'
     c = case c
-      of 'a':
-        when linearScanEnd == 'a': {.linearScanEnd.}
-        'A'
-      of 'b':
-        when linearScanEnd == 'b': {.linearScanEnd.}
-        'B'
-      of 'c':
-        when linearScanEnd == 'c': {.linearScanEnd.}
-        'C'
-      of 'd':
-        when linearScanEnd == 'd': {.linearScanEnd.}
-        'D'
-      of 'e':
-        when linearScanEnd == 'e': {.linearScanEnd.}
-        'E'
-      of 'f':
-        when linearScanEnd == 'f': {.linearScanEnd.}
-        'F'
-      of 'g':
-        when linearScanEnd == 'g': {.linearScanEnd.}
-        'G'
-      of 'h':
-        when linearScanEnd == 'h': {.linearScanEnd.}
-        'H'
-      of 'i':
-        when linearScanEnd == 'i': {.linearScanEnd.}
-        'I'
-      of 'j':
-        when linearScanEnd == 'j': {.linearScanEnd.}
-        'J'
-      of 'k':
-        when linearScanEnd == 'k': {.linearScanEnd.}
-        'K'
-      of 'l':
-        when linearScanEnd == 'l': {.linearScanEnd.}
-        'L'
-      of 'm':
-        when linearScanEnd == 'm': {.linearScanEnd.}
-        'M'
-      of 'n':
-        when linearScanEnd == 'n': {.linearScanEnd.}
-        'N'
-      of 'o':
-        when linearScanEnd == 'o': {.linearScanEnd.}
-        'O'
-      of 'p':
-        when linearScanEnd == 'p': {.linearScanEnd.}
-        'P'
-      of 'q':
-        when linearScanEnd == 'q': {.linearScanEnd.}
-        'Q'
-      of 'r':
-        when linearScanEnd == 'r': {.linearScanEnd.}
-        'R'
-      of 's':
-        when linearScanEnd == 's': {.linearScanEnd.}
-        'S'
-      of 't':
-        when linearScanEnd == 't': {.linearScanEnd.}
-        'T'
-      of 'u':
-        when linearScanEnd == 'u': {.linearScanEnd.}
-        'U'
-      of 'v':
-        when linearScanEnd == 'v': {.linearScanEnd.}
-        'V'
-      of 'w':
-        when linearScanEnd == 'w': {.linearScanEnd.}
-        'W'
-      of 'x':
-        when linearScanEnd == 'x': {.linearScanEnd.}
-        'X'
-      of 'y':
-        when linearScanEnd == 'y': {.linearScanEnd.}
-        'Y'
-      of 'z':
-        when linearScanEnd == 'z': {.linearScanEnd.}
-        'Z'
+      of 'a': 'A'
+      of 'b': 'B'
+      of 'c': 'C'
+      of 'd': 'D'
+      of 'e': 'E'
+      of 'f': 'F'
+      of 'g': 'G'
+      of 'h': 'H'
+      of 'i': 'I'
+      of 'j': 'J'
+      of 'k': 'K'
+      of 'l': 'L'
+      of 'm': 'M'
+      of 'n': 'N'
+      of 'o': 'O'
+      of 'p': 'P'
+      of 'q': 'Q'
+      of 'r': 'R'
+      of 's': 'S'
+      of 't': 'T'
+      of 'u': 'U'
+      of 'v': 'V'
+      of 'w': 'W'
+      of 'x': 'X'
+      of 'y': 'Y'
+      of 'z': 'Z'
       else: c
 
 
-  func toLowerAscii*(s: var string, linearScanEnd: static[char]) {.inline.} =
+  func toLowerAsciiInPlace*(s: var string) {.inline.} =
     ## Converts string `s` into lower case.
     ##
     ## This works only for the letters ``A-Z``. See `unicode.toLower
     ## <unicode.html#toLower,string>`_ for a version that works for any Unicode
     ## character.
     ##
-    ## ``linearScanEnd`` is a static ``char`` argument,
-    ## if it is on range ``'a'..'z'`` then it will add ``{.linearScanEnd.}`` pragma
-    ## at compile-time at that char position, reducing the case switch linear scan.
-    ##
-    ## Example: Imagine that you are working with Hexadecimal strings,
-    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``,
-    ## this is an optional compile-time optimization, is disabled by default.
-    ##
-    ## .. code-block:: nim
-    ##   echo toLowerAscii("#FFFFFF", linearScanEnd = 'f') ## Hexadecimal
-    ##
     ## See also:
     ## * `normalize proc<#normalize,string>`_
-    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
     runnableExamples:
       var stringy = "ABCDEF"
-      toLowerAscii(stringy, linearScanEnd = 'f')
+      toLowerAsciiInPlace(stringy)
       doAssert stringy == "abcdef"
       var strng = "NIM"
-      toLowerAscii(strng, linearScanEnd = 'n')
+      toLowerAsciiInPlace(strng)
       doAssert strng == "nim"
     var i = 0
     for c in mitems(s):
-      toLowerAscii(c, linearScanEnd)
+      toLowerAsciiInPlace(c)
       s[i] = c
       inc i
 
 
-  func toUpperAscii*(s: var string, linearScanEnd: static[char]) {.inline.} =
+  func toUpperAsciiInPlace*(s: var string) {.inline.} =
     ## Converts string `s` into upper case.
     ##
     ## This works only for the letters ``A-Z``.  See `unicode.toUpper
     ## <unicode.html#toUpper,string>`_ for a version that works for any Unicode
     ## character.
     ##
-    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
-    ## if the char is on the range ``'a'..'z'`` then it will add a
-    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
-    ## at compile-time at that char position, reducing the case switch linear scan.
-    ##
-    ## Example: Imagine that you are working with Hexadecimal strings,
-    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
-    ## This is an optional compile-time optimization, is disabled by default.
-    ##
-    ## .. code-block:: nim
-    ##   echo toUpperAscii("#ffffff", linearScanEnd = 'f') ## Hexadecimal
-    ##   echo toUpperAscii("acgt", linearScanEnd = 't')    ## DNA data
-    ##
     ## See also:
     ## * `capitalizeAscii proc<#capitalizeAscii,string>`_
-    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
     runnableExamples:
       var stringo = "abcdef"
-      toUpperAscii(stringo, linearScanEnd = 'f')
+      toUpperAsciiInPlace(stringo)
       doAssert stringo == "ABCDEF"
       var strng = "nim"
-      toUpperAscii(strng, linearScanEnd = 'n')
+      toUpperAsciiInPlace(strng)
       doAssert strng == "NIM"
     var i = 0
     for c in mitems(s):
-      toUpperAscii(c, linearScanEnd)
+      toUpperAsciiInPlace(c)
       s[i] = c
       inc i
 
 
-  func capitalizeAscii*(s: var string, linearScanEnd: static[char]) {.inline.} =
+  func capitalizeAsciiInPlace*(s: var string) {.inline.} =
     ## Converts the first character of string `s` into upper case.
     ##
     ## This works only for the letters ``A-Z``.
     ## Use `Unicode module<unicode.html>`_ for UTF-8 support.
     ##
-    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
-    ## if the char is on the range ``'a'..'z'`` then it will add a
-    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
-    ## at compile-time at that char position, reducing the case switch linear scan.
-    ##
-    ## Example: Imagine that you are working with Hexadecimal strings,
-    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
-    ## This is an optional compile-time optimization, is disabled by default.
-    ##
-    ## .. code-block:: nim
-    ##   echo capitalizeAscii("#ffffff", linearScanEnd = 'f') ## Hexadecimal
-    ##   echo capitalizeAscii("acgt", linearScanEnd = 't')    ## DNA data
-    ##
     ## See also:
     ## * `toUpperAscii proc<#toUpperAscii,char>`_
-    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
     runnableExamples:
       var stringu = "foo"
-      capitalizeAscii(stringu, linearScanEnd = 'f')
+      capitalizeAsciiInPlace(stringu)
       doAssert stringu == "Foo"
       var stringx = "-bar"
-      capitalizeAscii(stringx, linearScanEnd = 'r')
+      capitalizeAsciiInPlace(stringx)
       doAssert stringx == "-bar"
-    toUpperAscii(s[0], linearScanEnd)
+    toUpperAsciiInPlace(s[0])
 
 
 when isMainModule:

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2862,44 +2862,10 @@ proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl,
 
 
 since (1, 1):
-  template toLowerAsciiInPlace*(c: var char) =
-    ## Returns the lower case version of character ``c``.
-    ##
-    ## This works only for the letters ``A-Z``. See `unicode.toLower
-    ## <unicode.html#toLower,Rune>`_ for a version that works for any Unicode
-    ## character.
-    ##
-    ## See also:
-    ## * `isLowerAscii proc<#isLowerAscii,char>`_
-    ## * `toLowerAscii proc<#toLowerAscii,string>`_ for converting a string
-    runnableExamples:
-      var character = 'F'
-      toLowerAsciiInPlace(character)
-      doAssert character == 'f'
-      var chara = 'A'
-      toLowerAsciiInPlace(chara)
-      doAssert chara == 'a'
+  template toLowerAsciiInPlace(c: var char) =
     if c in {'A'..'Z'}: c = chr(ord(c) + (ord('a') - ord('A')))
 
-
-  template toUpperAsciiInPlace*(c: var char) =
-    ## Converts character `c` into upper case.
-    ##
-    ## This works only for the letters ``A-Z``.  See `unicode.toUpper
-    ## <unicode.html#toUpper,Rune>`_ for a version that works for any Unicode
-    ## character.
-    ##
-    ## See also:
-    ## * `isLowerAscii proc<#isLowerAscii,char>`_
-    ## * `toUpperAscii proc<#toUpperAscii,string>`_ for converting a string
-    ## * `capitalizeAscii proc<#capitalizeAscii,string>`_
-    runnableExamples:
-      var character = 'f'
-      toUpperAsciiInPlace(character)
-      doAssert character == 'F'
-      var chara = 'z'
-      toUpperAsciiInPlace(chara)
-      doAssert chara == 'Z'
+  template toUpperAsciiInPlace(c: var char) =
     if c in {'a'..'z'}: c = chr(ord(c) - (ord('a') - ord('A')))
 
 

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -215,7 +215,7 @@ template toImpl(call) =
   for i in 0..len(s) - 1:
     result[i] = call(s[i])
 
-proc toLowerAscii*(s: string): string {.inline, noSideEffect, procvar,
+proc toLowerAscii*(s: string): string {.noSideEffect, procvar,
   rtl, extern: "nsuToLowerAsciiStr".} =
   ## Converts string `s` into lower case.
   ##
@@ -249,7 +249,7 @@ proc toUpperAscii*(c: char): char {.noSideEffect, procvar,
   else:
     result = c
 
-proc toUpperAscii*(s: string): string {.inline, noSideEffect, procvar,
+proc toUpperAscii*(s: string): string {.noSideEffect, procvar,
   rtl, extern: "nsuToUpperAsciiStr".} =
   ## Converts string `s` into upper case.
   ##

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2878,11 +2878,8 @@ since (1, 1):
       var strng = "NIM"
       toLowerAsciiInPlace(strng)
       doAssert strng == "nim"
-    var i = 0
     for c in mitems(s):
       if c in {'A'..'Z'}: c = chr(ord(c) + (ord('a') - ord('A')))
-      s[i] = c
-      inc i
 
 
   func toUpperAsciiInPlace*(s: var string) {.inline.} =
@@ -2901,11 +2898,8 @@ since (1, 1):
       var strng = "nim"
       toUpperAsciiInPlace(strng)
       doAssert strng == "NIM"
-    var i = 0
     for c in mitems(s):
       if c in {'a'..'z'}: c = chr(ord(c) - (ord('a') - ord('A')))
-      s[i] = c
-      inc i
 
 
 when isMainModule:

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2862,13 +2862,6 @@ proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl,
 
 
 since (1, 1):
-  template toLowerAsciiInPlace(c: var char) =
-    if c in {'A'..'Z'}: c = chr(ord(c) + (ord('a') - ord('A')))
-
-  template toUpperAsciiInPlace(c: var char) =
-    if c in {'a'..'z'}: c = chr(ord(c) - (ord('a') - ord('A')))
-
-
   func toLowerAsciiInPlace*(s: var string) {.inline.} =
     ## Converts string `s` into lower case.
     ##
@@ -2887,7 +2880,7 @@ since (1, 1):
       doAssert strng == "nim"
     var i = 0
     for c in mitems(s):
-      toLowerAsciiInPlace(c)
+      if c in {'A'..'Z'}: c = chr(ord(c) + (ord('a') - ord('A')))
       s[i] = c
       inc i
 
@@ -2910,27 +2903,9 @@ since (1, 1):
       doAssert strng == "NIM"
     var i = 0
     for c in mitems(s):
-      toUpperAsciiInPlace(c)
+      if c in {'a'..'z'}: c = chr(ord(c) - (ord('a') - ord('A')))
       s[i] = c
       inc i
-
-
-  func capitalizeAsciiInPlace*(s: var string) {.inline.} =
-    ## Converts the first character of string `s` into upper case.
-    ##
-    ## This works only for the letters ``A-Z``.
-    ## Use `Unicode module<unicode.html>`_ for UTF-8 support.
-    ##
-    ## See also:
-    ## * `toUpperAscii proc<#toUpperAscii,char>`_
-    runnableExamples:
-      var stringu = "foo"
-      capitalizeAsciiInPlace(stringu)
-      doAssert stringu == "Foo"
-      var stringx = "-bar"
-      capitalizeAsciiInPlace(stringx)
-      doAssert stringx == "-bar"
-    toUpperAsciiInPlace(s[0])
 
 
 when isMainModule:

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2860,6 +2860,341 @@ proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl,
   ## Alias for isEmptyOrWhitespace
   result = isEmptyOrWhitespace(s)
 
+
+since (1, 1):
+  template toLowerAscii*(c: var char, linearScanEnd: static[char] = ' ') =
+    ## Returns the lower case version of character ``c``.
+    ##
+    ## This works only for the letters ``A-Z``. See `unicode.toLower
+    ## <unicode.html#toLower,Rune>`_ for a version that works for any Unicode
+    ## character.
+    ##
+    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
+    ## if the char is on the range ``'a'..'z'`` then it will add a
+    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
+    ## at compile-time at that char position, reducing the case switch linear scan.
+    ##
+    ## Example: Imagine that you are working with Hexadecimal strings,
+    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
+    ## This is an optional compile-time optimization, is disabled by default.
+    ##
+    ## .. code-block:: nim
+    ##   var character = 'F'  ## Hexadecimal
+    ##   toLowerAscii(character, linearScanEnd = 'f')
+    ##   doAssert character == 'f'
+    ##
+    ## See also:
+    ## * `isLowerAscii proc<#isLowerAscii,char>`_
+    ## * `toLowerAscii proc<#toLowerAscii,string>`_ for converting a string
+    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
+    runnableExamples:
+      var character = 'F'
+      toLowerAscii(character, linearScanEnd = 'f')
+      doAssert character == 'f'
+      var chara = 'A'
+      toLowerAscii(chara)
+      doAssert chara == 'a'
+    c = case c
+      of 'A':
+        when linearScanEnd == 'a': {.linearScanEnd.}
+        'a'
+      of 'B':
+        when linearScanEnd == 'b': {.linearScanEnd.}
+        'b'
+      of 'C':
+        when linearScanEnd == 'c': {.linearScanEnd.}
+        'c'
+      of 'D':
+        when linearScanEnd == 'd': {.linearScanEnd.}
+        'd'
+      of 'E':
+        when linearScanEnd == 'e': {.linearScanEnd.}
+        'e'
+      of 'F':
+        when linearScanEnd == 'f': {.linearScanEnd.}
+        'f'
+      of 'G':
+        when linearScanEnd == 'g': {.linearScanEnd.}
+        'g'
+      of 'H':
+        when linearScanEnd == 'h': {.linearScanEnd.}
+        'h'
+      of 'I':
+        when linearScanEnd == 'i': {.linearScanEnd.}
+        'i'
+      of 'J':
+        when linearScanEnd == 'j': {.linearScanEnd.}
+        'j'
+      of 'K':
+        when linearScanEnd == 'k': {.linearScanEnd.}
+        'k'
+      of 'L':
+        when linearScanEnd == 'l': {.linearScanEnd.}
+        'l'
+      of 'M':
+        when linearScanEnd == 'm': {.linearScanEnd.}
+        'm'
+      of 'N':
+        when linearScanEnd == 'n': {.linearScanEnd.}
+        'n'
+      of 'O':
+        when linearScanEnd == 'o': {.linearScanEnd.}
+        'o'
+      of 'P':
+        when linearScanEnd == 'p': {.linearScanEnd.}
+        'p'
+      of 'Q':
+        when linearScanEnd == 'q': {.linearScanEnd.}
+        'q'
+      of 'R':
+        when linearScanEnd == 'r': {.linearScanEnd.}
+        'r'
+      of 'S':
+        when linearScanEnd == 's': {.linearScanEnd.}
+        's'
+      of 'T':
+        when linearScanEnd == 't': {.linearScanEnd.}
+        't'
+      of 'U':
+        when linearScanEnd == 'u': {.linearScanEnd.}
+        'u'
+      of 'V':
+        when linearScanEnd == 'v': {.linearScanEnd.}
+        'v'
+      of 'W':
+        when linearScanEnd == 'w': {.linearScanEnd.}
+        'w'
+      of 'X':
+        when linearScanEnd == 'x': {.linearScanEnd.}
+        'x'
+      of 'Y':
+        when linearScanEnd == 'y': {.linearScanEnd.}
+        'y'
+      of 'Z':
+        when linearScanEnd == 'z': {.linearScanEnd.}
+        'z'
+      else: c
+
+
+  template toUpperAscii*(c: var char, linearScanEnd: static[char] = ' ') =
+    ## Converts character `c` into upper case.
+    ##
+    ## This works only for the letters ``A-Z``.  See `unicode.toUpper
+    ## <unicode.html#toUpper,Rune>`_ for a version that works for any Unicode
+    ## character.
+    ##
+    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
+    ## if the char is on the range ``'a'..'z'`` then it will add a
+    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
+    ## at compile-time at that char position, reducing the case switch linear scan.
+    ##
+    ## Example: Imagine that you are working with Hexadecimal strings,
+    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
+    ## This is an optional compile-time optimization, is disabled by default.
+    ##
+    ## .. code-block:: nim
+    ##   var character = 'F'  ## Hexadecimal
+    ##   toLowerAscii(character, linearScanEnd = 'f')
+    ##   doAssert character == 'f'
+    ##
+    ## See also:
+    ## * `isLowerAscii proc<#isLowerAscii,char>`_
+    ## * `toUpperAscii proc<#toUpperAscii,string>`_ for converting a string
+    ## * `capitalizeAscii proc<#capitalizeAscii,string>`_
+    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
+    runnableExamples:
+      var character = 'f'
+      toUpperAscii(character, linearScanEnd = 'f')
+      doAssert character == 'F'
+      var chara = 'z'
+      toUpperAscii(chara)
+      doAssert chara == 'Z'
+    c = case c
+      of 'a':
+        when linearScanEnd == 'a': {.linearScanEnd.}
+        'A'
+      of 'b':
+        when linearScanEnd == 'b': {.linearScanEnd.}
+        'B'
+      of 'c':
+        when linearScanEnd == 'c': {.linearScanEnd.}
+        'C'
+      of 'd':
+        when linearScanEnd == 'd': {.linearScanEnd.}
+        'D'
+      of 'e':
+        when linearScanEnd == 'e': {.linearScanEnd.}
+        'E'
+      of 'f':
+        when linearScanEnd == 'f': {.linearScanEnd.}
+        'F'
+      of 'g':
+        when linearScanEnd == 'g': {.linearScanEnd.}
+        'G'
+      of 'h':
+        when linearScanEnd == 'h': {.linearScanEnd.}
+        'H'
+      of 'i':
+        when linearScanEnd == 'i': {.linearScanEnd.}
+        'I'
+      of 'j':
+        when linearScanEnd == 'j': {.linearScanEnd.}
+        'J'
+      of 'k':
+        when linearScanEnd == 'k': {.linearScanEnd.}
+        'K'
+      of 'l':
+        when linearScanEnd == 'l': {.linearScanEnd.}
+        'L'
+      of 'm':
+        when linearScanEnd == 'm': {.linearScanEnd.}
+        'M'
+      of 'n':
+        when linearScanEnd == 'n': {.linearScanEnd.}
+        'N'
+      of 'o':
+        when linearScanEnd == 'o': {.linearScanEnd.}
+        'O'
+      of 'p':
+        when linearScanEnd == 'p': {.linearScanEnd.}
+        'P'
+      of 'q':
+        when linearScanEnd == 'q': {.linearScanEnd.}
+        'Q'
+      of 'r':
+        when linearScanEnd == 'r': {.linearScanEnd.}
+        'R'
+      of 's':
+        when linearScanEnd == 's': {.linearScanEnd.}
+        'S'
+      of 't':
+        when linearScanEnd == 't': {.linearScanEnd.}
+        'T'
+      of 'u':
+        when linearScanEnd == 'u': {.linearScanEnd.}
+        'U'
+      of 'v':
+        when linearScanEnd == 'v': {.linearScanEnd.}
+        'V'
+      of 'w':
+        when linearScanEnd == 'w': {.linearScanEnd.}
+        'W'
+      of 'x':
+        when linearScanEnd == 'x': {.linearScanEnd.}
+        'X'
+      of 'y':
+        when linearScanEnd == 'y': {.linearScanEnd.}
+        'Y'
+      of 'z':
+        when linearScanEnd == 'z': {.linearScanEnd.}
+        'Z'
+      else: c
+
+
+  func toLowerAscii*(s: var string, linearScanEnd: static[char] = ' ') {.inline.} =
+    ## Converts string `s` into lower case.
+    ##
+    ## This works only for the letters ``A-Z``. See `unicode.toLower
+    ## <unicode.html#toLower,string>`_ for a version that works for any Unicode
+    ## character.
+    ##
+    ## ``linearScanEnd`` is a static ``char`` argument,
+    ## if it is on range ``'a'..'z'`` then it will add ``{.linearScanEnd.}`` pragma
+    ## at compile-time at that char position, reducing the case switch linear scan.
+    ##
+    ## Example: Imagine that you are working with Hexadecimal strings,
+    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``,
+    ## this is an optional compile-time optimization, is disabled by default.
+    ##
+    ## .. code-block:: nim
+    ##   echo toLowerAscii("#FFFFFF", linearScanEnd = 'f') ## Hexadecimal
+    ##
+    ## See also:
+    ## * `normalize proc<#normalize,string>`_
+    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
+    runnableExamples:
+      var stringy = "ABCDEF"
+      toLowerAscii(stringy, linearScanEnd = 'f')
+      doAssert stringy == "abcdef"
+      var strng = "NIM"
+      toLowerAscii(strng)
+      doAssert strng == "nim"
+    var i = 0
+    for c in mitems(s):
+      toLowerAscii(c, linearScanEnd)
+      s[i] = c
+      inc i
+
+
+  func toUpperAscii*(s: var string, linearScanEnd: static[char] = ' ') {.inline.} =
+    ## Converts string `s` into upper case.
+    ##
+    ## This works only for the letters ``A-Z``.  See `unicode.toUpper
+    ## <unicode.html#toUpper,string>`_ for a version that works for any Unicode
+    ## character.
+    ##
+    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
+    ## if the char is on the range ``'a'..'z'`` then it will add a
+    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
+    ## at compile-time at that char position, reducing the case switch linear scan.
+    ##
+    ## Example: Imagine that you are working with Hexadecimal strings,
+    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
+    ## This is an optional compile-time optimization, is disabled by default.
+    ##
+    ## .. code-block:: nim
+    ##   echo toUpperAscii("#ffffff", linearScanEnd = 'f') ## Hexadecimal
+    ##   echo toUpperAscii("acgt", linearScanEnd = 't')    ## DNA data
+    ##
+    ## See also:
+    ## * `capitalizeAscii proc<#capitalizeAscii,string>`_
+    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
+    runnableExamples:
+      var stringo = "abcdef"
+      toUpperAscii(stringo, linearScanEnd = 'f')
+      doAssert stringo == "ABCDEF"
+      var strng = "nim"
+      toUpperAscii(strng)
+      doAssert strng == "NIM"
+    var i = 0
+    for c in mitems(s):
+      toUpperAscii(c, linearScanEnd)
+      s[i] = c
+      inc i
+
+
+  func capitalizeAscii*(s: var string, linearScanEnd: static[char] = ' ') {.inline.} =
+    ## Converts the first character of string `s` into upper case.
+    ##
+    ## This works only for the letters ``A-Z``.
+    ## Use `Unicode module<unicode.html>`_ for UTF-8 support.
+    ##
+    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
+    ## if the char is on the range ``'a'..'z'`` then it will add a
+    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
+    ## at compile-time at that char position, reducing the case switch linear scan.
+    ##
+    ## Example: Imagine that you are working with Hexadecimal strings,
+    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
+    ## This is an optional compile-time optimization, is disabled by default.
+    ##
+    ## .. code-block:: nim
+    ##   echo capitalizeAscii("#ffffff", linearScanEnd = 'f') ## Hexadecimal
+    ##   echo capitalizeAscii("acgt", linearScanEnd = 't')    ## DNA data
+    ##
+    ## See also:
+    ## * `toUpperAscii proc<#toUpperAscii,char>`_
+    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
+    runnableExamples:
+      var stringu = "foo"
+      capitalizeAscii(stringu, linearScanEnd = 'f')
+      doAssert stringu == "Foo"
+      var stringx = "-bar"
+      capitalizeAscii(stringx, linearScanEnd = 'f')
+      doAssert stringx == "-bar"
+    toUpperAscii(s[0], linearScanEnd)
+
+
 when isMainModule:
   proc nonStaticTests =
     doAssert formatBiggestFloat(1234.567, ffDecimal, -1) == "1234.567000"

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2879,34 +2879,7 @@ since (1, 1):
       var chara = 'A'
       toLowerAsciiInPlace(chara)
       doAssert chara == 'a'
-    c = case c
-      of 'A': 'a'
-      of 'B': 'b'
-      of 'C': 'c'
-      of 'D': 'd'
-      of 'E': 'e'
-      of 'F': 'f'
-      of 'G': 'g'
-      of 'H': 'h'
-      of 'I': 'i'
-      of 'J': 'j'
-      of 'K': 'k'
-      of 'L': 'l'
-      of 'M': 'm'
-      of 'N': 'n'
-      of 'O': 'o'
-      of 'P': 'p'
-      of 'Q': 'q'
-      of 'R': 'r'
-      of 'S': 's'
-      of 'T': 't'
-      of 'U': 'u'
-      of 'V': 'v'
-      of 'W': 'w'
-      of 'X': 'x'
-      of 'Y': 'y'
-      of 'Z': 'z'
-      else: c
+    if c in {'A'..'Z'}: c = chr(ord(c) + (ord('a') - ord('A')))
 
 
   template toUpperAsciiInPlace*(c: var char) =
@@ -2927,34 +2900,7 @@ since (1, 1):
       var chara = 'z'
       toUpperAsciiInPlace(chara)
       doAssert chara == 'Z'
-    c = case c
-      of 'a': 'A'
-      of 'b': 'B'
-      of 'c': 'C'
-      of 'd': 'D'
-      of 'e': 'E'
-      of 'f': 'F'
-      of 'g': 'G'
-      of 'h': 'H'
-      of 'i': 'I'
-      of 'j': 'J'
-      of 'k': 'K'
-      of 'l': 'L'
-      of 'm': 'M'
-      of 'n': 'N'
-      of 'o': 'O'
-      of 'p': 'P'
-      of 'q': 'Q'
-      of 'r': 'R'
-      of 's': 'S'
-      of 't': 'T'
-      of 'u': 'U'
-      of 'v': 'V'
-      of 'w': 'W'
-      of 'x': 'X'
-      of 'y': 'Y'
-      of 'z': 'Z'
-      else: c
+    if c in {'a'..'z'}: c = chr(ord(c) - (ord('a') - ord('A')))
 
 
   func toLowerAsciiInPlace*(s: var string) {.inline.} =

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -161,7 +161,7 @@ proc isSpaceAscii*(c: char): bool {.noSideEffect, procvar,
   return c in Whitespace
 
 proc isLowerAscii*(c: char): bool {.noSideEffect, procvar,
-  rtl, extern: "nsuIsLowerAsciiChar".} =
+  rtl, extern: "nsuIsLowerAsciiChar", inline.} =
   ## Checks whether or not `c` is a lower case character.
   ##
   ## This checks ASCII characters only.
@@ -176,7 +176,7 @@ proc isLowerAscii*(c: char): bool {.noSideEffect, procvar,
   return c in {'a'..'z'}
 
 proc isUpperAscii*(c: char): bool {.noSideEffect, procvar,
-  rtl, extern: "nsuIsUpperAsciiChar".} =
+  rtl, extern: "nsuIsUpperAsciiChar", inline.} =
   ## Checks whether or not `c` is an upper case character.
   ##
   ## This checks ASCII characters only.
@@ -2872,15 +2872,15 @@ since (1, 1):
     ## See also:
     ## * `normalize proc<#normalize,string>`_
     runnableExamples:
-      var stringy = "ABCDEF"
+      var stringy = "ABCDeF!"
       toLowerAsciiInPlace(stringy)
-      doAssert stringy == "abcdef"
-      var strng = "NIM"
-      toLowerAsciiInPlace(strng)
-      doAssert strng == "nim"
+      doAssert stringy == "abcdef!"
+      var str = "NIM"
+      toLowerAsciiInPlace(str)
+      doAssert str == "nim"
     for c in mitems(s):
-      if c in {'A'..'Z'}: c = chr(ord(c) + (ord('a') - ord('A')))
-
+      # faster than `if c.isUpperAscii: ...`
+      c = chr(c.ord + (if c.isUpperAscii: (ord('a') - ord('A')) else: 0))
 
   func toUpperAsciiInPlace*(s: var string) {.inline.} =
     ## Converts string `s` into upper case.
@@ -2892,14 +2892,14 @@ since (1, 1):
     ## See also:
     ## * `capitalizeAscii proc<#capitalizeAscii,string>`_
     runnableExamples:
-      var stringo = "abcdef"
+      var stringo = "ABCDeF!"
       toUpperAsciiInPlace(stringo)
-      doAssert stringo == "ABCDEF"
-      var strng = "nim"
-      toUpperAsciiInPlace(strng)
-      doAssert strng == "NIM"
+      doAssert stringo == "ABCDEF!"
+      var str = "nim"
+      toUpperAsciiInPlace(str)
+      doAssert str == "NIM"
     for c in mitems(s):
-      if c in {'a'..'z'}: c = chr(ord(c) - (ord('a') - ord('A')))
+      c = chr(c.ord + (if c.isLowerAscii: (ord('A') - ord('a')) else: 0))
 
 
 when isMainModule:

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -637,6 +637,19 @@ proc isLeapYear*(year: int): bool =
     doAssert not isLeapYear(1900)
   year mod 4 == 0 and (year mod 100 != 0 or year mod 400 == 0)
 
+proc isLeapDay*(t: DateTime): bool {.since: (1,1).} =
+  ## returns whether `t` is a leap day, ie, Feb 29 in a leap year. This matters
+  ## as it affects time offset calculations.
+  runnableExamples:
+    let t = initDateTime(29, mFeb, 2020, 00, 00, 00, utc())
+    doAssert t.isLeapDay
+    doAssert t+1.years-1.years != t
+    let t2 = initDateTime(28, mFeb, 2020, 00, 00, 00, utc())
+    doAssert not t2.isLeapDay
+    doAssert t2+1.years-1.years == t2
+    doAssertRaises(Exception): discard initDateTime(29, mFeb, 2021, 00, 00, 00, utc())
+  t.year.isLeapYear and t.month == mFeb and t.monthday == 29
+
 proc getDaysInMonth*(month: Month, year: int): int =
   ## Get the number of days in ``month`` of ``year``.
   # http://www.dispersiondesign.com/articles/time/number_of_days_in_a_month

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -701,7 +701,7 @@ proc capitalize*(s: string): string {.noSideEffect, procvar,
     doAssert capitalize("βeta") == "Βeta"
 
   if len(s) == 0:
-    return s
+    return ""
   var
     rune: Rune
     i = 0

--- a/lib/std/compilesettings.nim
+++ b/lib/std/compilesettings.nim
@@ -1,0 +1,54 @@
+#
+#
+#           The Nim Compiler
+#        (c) Copyright 2020 Nim Contributors
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## This module allows querying the compiler about
+## diverse configuration settings.
+
+# Note: Only add new enum values at the end to ensure binary compatibility with
+# other Nim compiler versions!
+
+type
+  SingleValueSetting* {.pure.} = enum ## \
+                      ## settings resulting in a single string value
+    arguments,        ## experimental: the arguments passed after '-r'
+    outFile,          ## experimental: the output file
+    outDir,           ## the output directory
+    nimcacheDir,      ## the location of the 'nimcache' directory
+    projectName,      ## the project's name that is being compiled
+    projectPath,      ## experimental: some path to the project that is being compiled
+    projectFull,      ## the full path to the project that is being compiled
+    command,          ## experimental: the command (e.g. 'c', 'cpp', 'doc') passed to
+                      ## the Nim compiler
+    commandLine,      ## experimental: the command line passed to Nim
+    linkOptions,      ## additional options passed to the linker
+    compileOptions,   ## additional options passed to the C/C++ compiler
+    ccompilerPath     ## the path to the C/C++ compiler
+
+  MultipleValueSetting* {.pure.} = enum ## \
+                      ## settings resulting in a seq of string values
+    nimblePaths,      ## the nimble path(s)
+    searchPaths,      ## the search path for modules
+    lazyPaths,        ## experimental: even more paths
+    commandArgs,      ## the arguments passed to the Nim compiler
+    cincludes,        ## the #include paths passed to the C/C++ compiler
+    clibs             ## libraries passed to the C/C++ compiler
+
+proc querySetting*(setting: SingleValueSetting): string {.
+  compileTime, noSideEffect.} = discard
+  ## Can be used to get a string compile-time option. Example:
+  ##
+  ## .. code-block:: Nim
+  ##   const nimcache = querySetting(SingleValueSetting.nimcacheDir)
+
+proc querySettingSeq*(setting: MultipleValueSetting): seq[string] {.
+  compileTime, noSideEffect.} = discard
+  ## Can be used to get a multi-string compile-time option. Example:
+  ##
+  ## .. code-block:: Nim
+  ##   const nimblePaths = compileSettingSeq(MultipleValueSetting.nimblePaths)

--- a/lib/std/private/underscored_calls.nim
+++ b/lib/std/private/underscored_calls.nim
@@ -1,0 +1,38 @@
+
+#
+#
+#            Nim's Runtime Library
+#        (c) Copyright 2020 Andreas Rumpf
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## This is an internal helper module. Do not use.
+
+import macros
+
+proc underscoredCall*(n, arg0: NimNode): NimNode =
+  proc underscorePos(n: NimNode): int =
+    for i in 1 ..< n.len:
+      if n[i].eqIdent("_"): return i
+    return -1
+
+  if n.kind in nnkCallKinds:
+    result = copyNimNode(n)
+    result.add n[0]
+
+    let u = underscorePos(n)
+    if u < 0:
+      result.add arg0
+      for i in 1..n.len-1: result.add n[i]
+    else:
+      for i in 1..u-1: result.add n[i]
+      result.add arg0
+      for i in u+1..n.len-1: result.add n[i]
+  else:
+    # handle e.g. 'x.dup(sort)'
+    result = newNimNode(nnkCall, n)
+    result.add n
+    result.add arg0
+

--- a/lib/std/with.nim
+++ b/lib/std/with.nim
@@ -1,0 +1,58 @@
+#
+#
+#            Nim's Runtime Library
+#        (c) Copyright 2020 Andreas Rumpf
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## This module implements the ``with`` macro for easy
+## function chaining. See https://github.com/nim-lang/RFCs/issues/193
+## and https://github.com/nim-lang/RFCs/issues/192 for details leading to this
+## particular design.
+##
+## **Since** version 1.2.
+
+import macros, private / underscored_calls
+
+macro with*(arg: typed; calls: varargs[untyped]): untyped =
+  ## This macro provides the `chaining`:idx: of function calls.
+  ## It does so by patching every call in `calls` to
+  ## use `arg` as the first argument.
+  ## **This evaluates `arg` multiple times!**
+  runnableExamples:
+    var x = "yay"
+    with x:
+      add "abc"
+      add "efg"
+    doAssert x == "yayabcefg"
+
+    var a = 44
+    with a:
+      += 4
+      -= 5
+    doAssert a == 43
+
+  result = newNimNode(nnkStmtList, arg)
+  expectKind calls, nnkArgList
+  let body =
+    if calls.len == 1 and calls[0].kind in {nnkStmtList, nnkStmtListExpr}:
+      calls[0]
+    else:
+      calls
+  for call in body:
+    result.add underscoredCall(call, arg)
+
+when isMainModule:
+  type
+    Foo = object
+      col, pos: string
+
+  proc setColor(f: var Foo; r, g, b: int) = f.col = $(r, g, b)
+  proc setPosition(f: var Foo; x, y: float) = f.pos = $(x, y)
+
+  var f: Foo
+  with(f, setColor(2, 3, 4), setPosition(0.0, 1.0))
+  echo f
+

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -87,6 +87,18 @@ proc defined*(x: untyped): bool {.magic: "Defined", noSideEffect, compileTime.}
   ##     # Do here programmer friendly expensive sanity checks.
   ##   # Put here the normal code
 
+when defined(nimHashOrdinalFixed):
+  type
+    Ordinal*[T] {.magic: Ordinal.} ## Generic ordinal type. Includes integer,
+                                   ## bool, character, and enumeration types
+                                   ## as well as their subtypes. See also
+                                   ## `SomeOrdinal`.
+else:
+  # bootstrap <= 0.20.0
+  type
+    OrdinalImpl[T] {.magic: Ordinal.}
+    Ordinal* = OrdinalImpl | uint | uint64
+
 when defined(nimHasRunnableExamples):
   proc runnableExamples*(body: untyped) {.magic: "RunnableExamples".}
     ## A section you should use to mark `runnable example`:idx: code with.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2525,6 +2525,9 @@ proc staticRead*(filename: string): string {.magic: "Slurp".}
   ## Compile-time `readFile <io.html#readFile,string>`_ proc for easy
   ## `resource`:idx: embedding:
   ##
+  ## The maximum file size limit that ``staticRead`` and ``slurp`` can read is
+  ## near or equal to the *free* memory of the device you are using to compile.
+  ##
   ## .. code-block:: Nim
   ##     const myResource = staticRead"mydatafile.bin"
   ##

--- a/lib/system/arithmetics.nim
+++ b/lib/system/arithmetics.nim
@@ -22,7 +22,7 @@ proc pred*[T: Ordinal](x: T, y = 1): T {.magic: "Pred", noSideEffect.}
   ##   echo pred(5)    # => 4
   ##   echo pred(5, 3) # => 2
 
-proc inc*[T: Ordinal|uint|uint64](x: var T, y = 1) {.magic: "Inc", noSideEffect.}
+proc inc*[T: Ordinal](x: var T, y = 1) {.magic: "Inc", noSideEffect.}
   ## Increments the ordinal ``x`` by ``y``.
   ##
   ## If such a value does not exist, ``OverflowError`` is raised or a compile
@@ -33,7 +33,7 @@ proc inc*[T: Ordinal|uint|uint64](x: var T, y = 1) {.magic: "Inc", noSideEffect.
   ##  inc(i)    # i <- 3
   ##  inc(i, 3) # i <- 6
 
-proc dec*[T: Ordinal|uint|uint64](x: var T, y = 1) {.magic: "Dec", noSideEffect.}
+proc dec*[T: Ordinal](x: var T, y = 1) {.magic: "Dec", noSideEffect.}
   ## Decrements the ordinal ``x`` by ``y``.
   ##
   ## If such a value does not exist, ``OverflowError`` is raised or a compile

--- a/lib/system/assertions.nim
+++ b/lib/system/assertions.nim
@@ -15,8 +15,10 @@ proc `$`(info: InstantiationInfo): string =
 
 # ---------------------------------------------------------------------------
 
+when not defined(nimHasSinkInference):
+  {.pragma: nosinks.}
 
-proc raiseAssert*(msg: string) {.noinline, noreturn.} =
+proc raiseAssert*(msg: string) {.noinline, noreturn, nosinks.} =
   sysFatal(AssertionError, msg)
 
 proc failedAssertImpl*(msg: string) {.raises: [], tags: [].} =

--- a/lib/system/basic_types.nim
+++ b/lib/system/basic_types.nim
@@ -20,10 +20,6 @@ const
   off* = false  ## Alias for ``false``.
 
 type
-  Ordinal*[T] {.magic: Ordinal.} ## Generic ordinal type. Includes integer,
-                                 ## bool, character, and enumeration types
-                                 ## as well as their subtypes.
-
   SomeSignedInt* = int|int8|int16|int32|int64
     ## Type class matching all signed integer types.
 
@@ -35,7 +31,7 @@ type
 
   SomeOrdinal* = int|int8|int16|int32|int64|bool|enum|uint|uint8|uint16|uint32|uint64
     ## Type class matching all ordinal types; however this includes enums with
-    ## holes.
+    ## holes. See also `Ordinal`
 
   BiggestInt* = int64
     ## is an alias for the biggest signed integer type the Nim compiler

--- a/lib/system/basic_types.nim
+++ b/lib/system/basic_types.nim
@@ -1,18 +1,18 @@
 type
-  int* {.magic: Int.}         ## Default integer type; bitwidth depends on
+  int* {.magic: "Int".}         ## Default integer type; bitwidth depends on
                               ## architecture, but is always the same as a pointer.
-  int8* {.magic: Int8.}       ## Signed 8 bit integer type.
-  int16* {.magic: Int16.}     ## Signed 16 bit integer type.
-  int32* {.magic: Int32.}     ## Signed 32 bit integer type.
-  int64* {.magic: Int64.}     ## Signed 64 bit integer type.
-  uint* {.magic: UInt.}       ## Unsigned default integer type.
-  uint8* {.magic: UInt8.}     ## Unsigned 8 bit integer type.
-  uint16* {.magic: UInt16.}   ## Unsigned 16 bit integer type.
-  uint32* {.magic: UInt32.}   ## Unsigned 32 bit integer type.
-  uint64* {.magic: UInt64.}   ## Unsigned 64 bit integer type.
+  int8* {.magic: "Int8".}       ## Signed 8 bit integer type.
+  int16* {.magic: "Int16".}     ## Signed 16 bit integer type.
+  int32* {.magic: "Int32".}     ## Signed 32 bit integer type.
+  int64* {.magic: "Int64".}     ## Signed 64 bit integer type.
+  uint* {.magic: "UInt".}       ## Unsigned default integer type.
+  uint8* {.magic: "UInt8".}     ## Unsigned 8 bit integer type.
+  uint16* {.magic: "UInt16".}   ## Unsigned 16 bit integer type.
+  uint32* {.magic: "UInt32".}   ## Unsigned 32 bit integer type.
+  uint64* {.magic: "UInt64".}   ## Unsigned 64 bit integer type.
 
 type # we need to start a new type section here, so that ``0`` can have a type
-  bool* {.magic: Bool.} = enum ## Built-in boolean type.
+  bool* {.magic: "Bool".} = enum ## Built-in boolean type.
     false = 0, true = 1
 
 const

--- a/lib/system/inclrtl.nim
+++ b/lib/system/inclrtl.nim
@@ -49,7 +49,7 @@ when defined(nimlocks):
 else:
   {.pragma: benign, gcsafe.}
 
-template since(version, body: untyped) {.dirty.} =
+template since(version, body: untyped) {.dirty, used.} =
   ## limitation: can't be used to annotate a template (eg typetraits.get), would
   ## error: cannot attach a custom pragma.
   when (NimMajor, NimMinor) >= version:

--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -44,8 +44,8 @@ proc writeVersion() =
 
 type
   PrettyOptions = object
-    indWidth: int
-    maxLineLen: int
+    indWidth: Natural
+    maxLineLen: Positive
 
 proc prettyPrint(infile, outfile: string, opt: PrettyOptions) =
   var conf = newConfigRef()

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -252,10 +252,10 @@ proc toSocket(stdoutSocket: Socket) {.gcsafe.} =
     let res = results.recv()
     case res.section
     of ideNone: break
-    of ideMsg: stdoutSocket.send(res.doc)
-    of ideKnown: stdoutSocket.send($(res.quality == 1))
-    of ideProject: stdoutSocket.send(res.filePath)
-    else: stdoutSocket.send($res)
+    of ideMsg: stdoutSocket.send(res.doc & "\c\L")
+    of ideKnown: stdoutSocket.send($(res.quality == 1) & "\c\L")
+    of ideProject: stdoutSocket.send(res.filePath & "\c\L")
+    else: stdoutSocket.send($res & "\c\L")
 
 proc toEpc(client: Socket; uid: BiggestInt) {.gcsafe.} =
   var list = newSList()

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -252,10 +252,10 @@ proc toSocket(stdoutSocket: Socket) {.gcsafe.} =
     let res = results.recv()
     case res.section
     of ideNone: break
-    of ideMsg: stdoutSocket.send(res.doc & "\c\L")
-    of ideKnown: stdoutSocket.send($(res.quality == 1) & "\c\L")
-    of ideProject: stdoutSocket.send(res.filePath & "\c\L")
-    else: stdoutSocket.send($res & "\c\L")
+    of ideMsg: stdoutSocket.send(res.doc)
+    of ideKnown: stdoutSocket.send($(res.quality == 1))
+    of ideProject: stdoutSocket.send(res.filePath)
+    else: stdoutSocket.send($res)
 
 proc toEpc(client: Socket; uid: BiggestInt) {.gcsafe.} =
   var list = newSList()

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -10,7 +10,7 @@
 ## Include for the tester that contains test suites that test special features
 ## of the compiler.
 
-# included from tester.nim
+# included from testament.nim
 
 import important_packages
 
@@ -456,10 +456,8 @@ let
   packageIndex = nimbleDir / "packages_official.json"
 
 iterator listPackages(): tuple[name, url, cmd: string, hasDeps: bool] =
-  let defaultCmd = "nimble test"
   let packageList = parseFile(packageIndex)
   for n, cmd, hasDeps, url in important_packages.packages.items:
-    let cmd = if cmd.len == 0: defaultCmd else: cmd
     if url.len != 0:
       yield (n, url, cmd, hasDeps)
     else:

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -1,96 +1,95 @@
 
-template pkg(name: string; cmd = "nimble test"; hasDeps = false; url = ""): untyped =
+template pkg(name: string; hasDeps = false; cmd = "nimble test"; url = ""): untyped =
   packages.add((name, cmd, hasDeps, url))
 
 var packages*: seq[tuple[name, cmd: string; hasDeps: bool; url: string]] = @[]
 
 
 pkg "argparse"
-pkg "arraymancer", "nim c tests/tests_cpu.nim", true
-pkg "ast_pattern_matching", "nim c -r --oldgensym:on tests/test1.nim"
-pkg "asyncmysql", "", true
+pkg "arraymancer", true, "nim c tests/tests_cpu.nim"
+pkg "ast_pattern_matching", false, "nim c -r --oldgensym:on tests/test1.nim"
+pkg "asyncmysql", true
 pkg "bigints"
-pkg "binaryheap", "nim c -r binaryheap.nim"
+pkg "binaryheap", false, "nim c -r binaryheap.nim"
 # pkg "blscurve", "", true # pending https://github.com/status-im/nim-blscurve/issues/39
-pkg "bncurve", "", true
-pkg "c2nim", "nim c testsuite/tester.nim"
+pkg "bncurve", true
+pkg "c2nim", false, "nim c testsuite/tester.nim"
 pkg "cascade"
 pkg "chroma"
-pkg "chronicles", "nim c -o:chr -r chronicles.nim", true
-pkg "chronos", "", true
-pkg "cligen", "nim c -o:cligenn -r cligen.nim"
-pkg "coco", "", true
+pkg "chronicles", true, "nim c -o:chr -r chronicles.nim"
+pkg "chronos", true
+pkg "cligen", false, "nim c -o:cligenn -r cligen.nim"
+pkg "coco", true
 pkg "combparser"
 pkg "compactdict"
-pkg "comprehension", "", false, "https://github.com/alehander42/comprehension"
+pkg "comprehension", false, "nimble test", "https://github.com/alehander42/comprehension"
 pkg "criterion"
-pkg "dashing", "nim c tests/functional.nim"
+pkg "dashing", false, "nim c tests/functional.nim"
 pkg "docopt"
-pkg "easygl", "nim c -o:egl -r src/easygl.nim", true, "https://github.com/jackmott/easygl"
+pkg "easygl", true, "nim c -o:egl -r src/easygl.nim", "https://github.com/jackmott/easygl"
 pkg "elvis"
-pkg "fragments", "nim c -r fragments/dsl.nim"
+pkg "fragments", false, "nim c -r fragments/dsl.nim"
 pkg "gara"
-pkg "ggplotnim", "nimble testCI", true
+pkg "ggplotnim", true, "nimble testCI"
 pkg "glob"
 pkg "gnuplot"
-# pkg "godot", "nim c -r godot/godot.nim" # not yet compatible with Nim 0.19
-pkg "hts", "nim c -o:htss src/hts.nim"
-pkg "illwill", "nimble examples"
+pkg "hts", false, "nim c -o:htss src/hts.nim"
+pkg "illwill", false, "nimble examples"
 pkg "inim"
-pkg "itertools", "nim doc src/itertools.nim"
+pkg "itertools", false, "nim doc src/itertools.nim"
 pkg "iterutils"
 pkg "jstin"
-pkg "karax", "nim c -r tests/tester.nim"
+pkg "karax", false, "nim c -r tests/tester.nim"
 pkg "loopfusion"
 pkg "msgpack4nim"
-pkg "nake", "nim c nakefile.nim"
-pkg "neo", "nim c -d:blas=openblas tests/all.nim", true
+pkg "nake", false, "nim c nakefile.nim"
+pkg "neo", true, "nim c -d:blas=openblas tests/all.nim"
 # pkg "nico", "", true
-pkg "nicy", "nim c src/nicy.nim"
-pkg "nigui", "nim c -o:niguii -r src/nigui.nim"
-pkg "nimcrypto", "nim c -r tests/testall.nim"
-pkg "NimData", "nim c -o:nimdataa src/nimdata.nim", true
-pkg "nimes", "nim c src/nimes.nim", true
-pkg "nimfp", "nim c -o:nfp -r src/fp.nim", true
-pkg "nimgame2", "nim c nimgame2/nimgame.nim", true
-pkg "nimgen", "nim c -o:nimgenn -r src/nimgen/runcfg.nim", true
+pkg "nicy", false, "nim c src/nicy.nim"
+pkg "nigui", false, "nim c -o:niguii -r src/nigui.nim"
+pkg "nimcrypto", false, "nim c -r tests/testall.nim"
+pkg "NimData", true, "nim c -o:nimdataa src/nimdata.nim"
+pkg "nimes", true, "nim c src/nimes.nim"
+pkg "nimfp", true, "nim c -o:nfp -r src/fp.nim"
+pkg "nimgame2", true, "nim c nimgame2/nimgame.nim"
+pkg "nimgen", true, "nim c -o:nimgenn -r src/nimgen/runcfg.nim"
 # pkg "nimlsp", "", true
-pkg "nimly", "", true
+pkg "nimly", true
 # pkg "nimongo", "nimble test_ci", true
-pkg "nimpy", "nim c -r tests/nimfrompy.nim"
+pkg "nimpy", false, "nim c -r tests/nimfrompy.nim"
 pkg "nimquery"
-pkg "nimsl", "", true
+pkg "nimsl", true
 pkg "nimsvg"
 # pkg "nimterop", "", true
-pkg "nimx", "nim c --threads:on test/main.nim", true
-pkg "norm", "nim c -r tests/tsqlite.nim", true
+pkg "nimx", true, "nim c --threads:on test/main.nim"
+pkg "norm", true, "nim c -r tests/tsqlite.nim"
 pkg "npeg"
-pkg "ormin", "nim c -o:orminn ormin.nim", true
+pkg "ormin", true, "nim c -o:orminn ormin.nim"
 pkg "parsetoml"
 pkg "patty"
-pkg "plotly", "nim c --oldgensym:on examples/all.nim", true
+pkg "plotly", true, "nim c --oldgensym:on examples/all.nim"
 pkg "pnm"
 pkg "polypbren"
-pkg "protobuf", "nim c -o:protobuff -r src/protobuf.nim", true
+pkg "protobuf", true, "nim c -o:protobuff -r src/protobuf.nim"
 pkg "rbtree"
-pkg "react", "nimble example"
-pkg "regex", "nim c src/regex", true
-pkg "result", "nim c -r result.nim"
-pkg "rosencrantz", "nim c -o:rsncntz -r rosencrantz.nim"
-pkg "sdl1", "nim c -r src/sdl.nim"
-pkg "sdl2_nim", "nim c -r sdl2/sdl.nim"
-pkg "snip", "", false, "https://github.com/genotrance/snip"
-pkg "stint", "nim c -o:stintt -r stint.nim"
-pkg "strunicode", "nim c -r src/strunicode.nim", true
-pkg "telebot", "nim c -o:tbot --oldgensym:on -r telebot.nim", true
+pkg "react", false, "nimble example"
+pkg "regex", true, "nim c src/regex"
+pkg "result", false, "nim c -r result.nim"
+pkg "rosencrantz", false, "nim c -o:rsncntz -r rosencrantz.nim"
+pkg "sdl1", false, "nim c -r src/sdl.nim"
+pkg "sdl2_nim", false, "nim c -r sdl2/sdl.nim"
+pkg "snip", false, "nimble test", "https://github.com/genotrance/snip"
+pkg "stint", false, "nim c -o:stintt -r stint.nim"
+pkg "strunicode", true, "nim c -r src/strunicode.nim"
+pkg "telebot", true, "nim c -o:tbot --oldgensym:on -r telebot.nim"
 pkg "tempdir"
-pkg "tensordsl", "nim c -r tests/tests.nim", false, "https://krux02@bitbucket.org/krux02/tensordslnim.git"
+pkg "tensordsl", false, "nim c -r tests/tests.nim", "https://krux02@bitbucket.org/krux02/tensordslnim.git"
 pkg "tiny_sqlite"
 pkg "unicodedb"
-pkg "unicodeplus", "", true
+pkg "unicodeplus", true
 pkg "unpack"
 # pkg "winim", "", true
 pkg "with"
 pkg "ws"
 pkg "yaml"
-pkg "zero_functional", "nim c -r test.nim"
+pkg "zero_functional", false, "nim c -r test.nim"

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -11,7 +11,7 @@ pkg "ast_pattern_matching", false, "nim c -r --oldgensym:on tests/test1.nim"
 pkg "asyncmysql", true
 pkg "bigints"
 pkg "binaryheap", false, "nim c -r binaryheap.nim"
-# pkg "blscurve", "", true # pending https://github.com/status-im/nim-blscurve/issues/39
+# pkg "blscurve", true # pending https://github.com/status-im/nim-blscurve/issues/39
 pkg "bncurve", true
 pkg "c2nim", false, "nim c testsuite/tester.nim"
 pkg "cascade"
@@ -44,7 +44,7 @@ pkg "loopfusion"
 pkg "msgpack4nim"
 pkg "nake", false, "nim c nakefile.nim"
 pkg "neo", true, "nim c -d:blas=openblas tests/all.nim"
-# pkg "nico", "", true
+# pkg "nico", true
 pkg "nicy", false, "nim c src/nicy.nim"
 pkg "nigui", false, "nim c -o:niguii -r src/nigui.nim"
 pkg "nimcrypto", false, "nim c -r tests/testall.nim"
@@ -53,14 +53,14 @@ pkg "nimes", true, "nim c src/nimes.nim"
 pkg "nimfp", true, "nim c -o:nfp -r src/fp.nim"
 pkg "nimgame2", true, "nim c nimgame2/nimgame.nim"
 pkg "nimgen", true, "nim c -o:nimgenn -r src/nimgen/runcfg.nim"
-# pkg "nimlsp", "", true
+# pkg "nimlsp", true
 pkg "nimly", true
-# pkg "nimongo", "nimble test_ci", true
+# pkg "nimongo", true, "nimble test_ci"
 pkg "nimpy", false, "nim c -r tests/nimfrompy.nim"
 pkg "nimquery"
 pkg "nimsl", true
 pkg "nimsvg"
-# pkg "nimterop", "", true
+# pkg "nimterop", true
 pkg "nimx", true, "nim c --threads:on test/main.nim"
 pkg "norm", true, "nim c -r tests/tsqlite.nim"
 pkg "npeg"
@@ -88,7 +88,7 @@ pkg "tiny_sqlite"
 pkg "unicodedb"
 pkg "unicodeplus", true
 pkg "unpack"
-# pkg "winim", "", true
+# pkg "winim", true
 pkg "with"
 pkg "ws"
 pkg "yaml"

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -11,7 +11,7 @@ pkg "ast_pattern_matching", "nim c -r --oldgensym:on tests/test1.nim"
 pkg "asyncmysql", "", true
 pkg "bigints"
 pkg "binaryheap", "nim c -r binaryheap.nim"
-pkg "blscurve", "", true
+# pkg "blscurve", "", true # pending https://github.com/status-im/nim-blscurve/issues/39
 pkg "bncurve", "", true
 pkg "c2nim", "nim c testsuite/tester.nim"
 pkg "cascade"

--- a/tests/assert/tassert_c.nim
+++ b/tests/assert/tassert_c.nim
@@ -6,8 +6,8 @@ discard """
 const expected = """
 tassert_c.nim(35)        tassert_c
 tassert_c.nim(34)        foo
-assertions.nim(27)       failedAssertImpl
-assertions.nim(20)       raiseAssert
+assertions.nim(29)       failedAssertImpl
+assertions.nim(22)       raiseAssert
 fatal.nim(55)            sysFatal"""
 
 proc tmatch(x, p: string): bool =

--- a/tests/casestmt/tcasestmt.nim
+++ b/tests/casestmt/tcasestmt.nim
@@ -250,3 +250,40 @@ proc negativeOrNot(num: int): string =
 doAssert negativeOrNot(-1) == "negative"
 doAssert negativeOrNot(10000000) == "zero or positive"
 doAssert negativeOrNot(0) == "zero or positive"
+
+########################################################
+# issue #13490
+import strutils
+func foo(input: string): int =
+  try:
+    parseInt(input)
+  except:
+    return
+
+func foo2(b, input: string): int =
+  case b:
+    of "Y":
+      for c in input:
+        result =  if c in '0'..'9': parseInt($c)
+                  else: break
+    of "N":
+      for c in input:
+        result =  if c in '0'..'9': parseInt($c)
+                  else: continue
+    else: return
+
+
+static:
+  doAssert(foo("3") == 3)
+  doAssert(foo("a") == 0)
+  doAssert(foo2("Y", "a2") == 0)
+  doAssert(foo2("Y", "2a") == 2)
+  doAssert(foo2("N", "a3") == 3)
+  doAssert(foo2("z", "2") == 0)
+
+doAssert(foo("3") == 3)
+doAssert(foo("a") == 0)
+doAssert(foo2("Y", "a2") == 0)
+doAssert(foo2("Y", "2a") == 2)
+doAssert(foo2("N", "a3") == 3)
+doAssert(foo2("z", "2") == 0)

--- a/tests/destructor/tarc2.nim
+++ b/tests/destructor/tarc2.nim
@@ -13,8 +13,12 @@ proc create(): T = T(s: @[], data: "abc")
 proc addX(x: T; data: string) =
   x.data = data
 
+{.push sinkInference: off.}
+
 proc addX(x: T; child: T) =
   x.s.add child
+
+{.pop.}
 
 proc main(rootName: string) =
   var root = create()

--- a/tests/destructor/tconsume_twice.nim
+++ b/tests/destructor/tconsume_twice.nim
@@ -1,7 +1,7 @@
 discard """
   cmd: "nim c --newruntime $file"
-  errormsg: "sink parameter `a` is already consumed at tconsume_twice.nim(11, 10)"
-  line: 13
+  errormsg: "'=' is not available for type <owned Foo>; requires a copy because it's not the last read of 'a'; another read is done here: tconsume_twice.nim(13, 10); routine: consumeTwice"
+  line: 11
 """
 type
   Foo = ref object

--- a/tests/errmsgs/tsigmatch.nim
+++ b/tests/errmsgs/tsigmatch.nim
@@ -98,13 +98,13 @@ expression: fun1(default(Mystring), "asdf")
 
 
 ## line 100
-block:
+when true:
   # bug #11061 Type mismatch error "first type mismatch at" points to wrong argument/position
   # Note: the error msg now gives correct position for mismatched argument
   type
     A = object of RootObj
     B = object of A
-
+block:
   proc f(b: B) = discard
   proc f(a: A) = discard
 
@@ -163,7 +163,7 @@ block:
   var foo = ""
   f(foo, a0 = 12)
 
-block:
+when true:
   type Mystring = string
   type MyInt = int
   proc fun1(a1: MyInt, a2: Mystring) = discard

--- a/tests/errmsgs/tsigmatch2.nim
+++ b/tests/errmsgs/tsigmatch2.nim
@@ -28,11 +28,11 @@ expression: foo 1
 
 
 # line 30
-
+type Foo = object
 block: # issue #13182
   proc myproc(a: int): string = $("myproc", a)
   proc foo(args: varargs[string, myproc]): string = $args
-  type Foo = object
+
   proc foo(i: Foo): string = "in foo(i)"
   static: doAssert foo(Foo()) == "in foo(i)"
   static: doAssert foo(1) == """["(\"myproc\", 1)"]"""

--- a/tests/gc/gcleak.nim
+++ b/tests/gc/gcleak.nim
@@ -12,7 +12,14 @@ type
 proc makeObj(): TTestObj =
   result.x = "Hello"
 
-for i in 1 .. 100_000:
+const numIter =
+  # see tests/gc/gcleak2.nim
+  when defined(boehmgc):
+    1_000
+  elif defined(gcMarkAndSweep): 10_000
+  else: 100_000
+
+for i in 1 .. numIter:
   when defined(gcMarkAndSweep) or defined(boehmgc):
     GC_fullcollect()
   var obj = makeObj()

--- a/tests/gc/gcleak2.nim
+++ b/tests/gc/gcleak2.nim
@@ -14,8 +14,20 @@ proc makeObj(): TTestObj =
   result.x = "Hello"
   result.s = @[1,2,3]
 
+const numIter =
+  when defined(boehmgc):
+    # super slow because GC_fullcollect() at each iteration; especially
+    # on OSX 10.15 where it takes ~170s
+    # `getOccupiedMem` should be constant after each iteration for i >= 3
+    1_000
+  elif defined(gcMarkAndSweep):
+    # likewise, somewhat slow, 1_000_000 would run for 8s
+    # and same remark as above
+    100_000
+  else: 1_000_000
+
 proc inProc() =
-  for i in 1 .. 1_000_000:
+  for i in 1 .. numIter:
     when defined(gcMarkAndSweep) or defined(boehmgc):
       GC_fullcollect()
     var obj: TTestObj

--- a/tests/gc/gcleak2.nim
+++ b/tests/gc/gcleak2.nim
@@ -2,11 +2,6 @@ discard """
   outputsub: "no leak: "
 """
 
-## this test makes sure getOccupiedMem() is constant after a few iterations
-## for --gc:bohem, --gc:markAndSweep, --gc:arc, --gc:orc.
-## and for other gc, it consists of cycles with constant min/max after a few cycles.
-## This ensures we have no leaks.
-
 when defined(GC_setMaxPause):
   GC_setMaxPause 2_000
 
@@ -19,75 +14,13 @@ proc makeObj(): TTestObj =
   result.x = "Hello"
   result.s = @[1,2,3]
 
-const collectAlways = defined(gcMarkAndSweep) or defined(boehmgc)
-const isDeterministic = collectAlways or defined(gcArc) or defined(gcOrc)
-  ## when isDeterministic, we expect memory to reach a fixed point
-  ## after `numIterStable` iterations
-
-var memMax = 0 # peak
-
-when isDeterministic:
-  const numIterStable = 3
-    # stabilize after this many iterations
-else:
-  const numCycleStable = when defined(useRealtimeGC): 6 else: 4
-    # stabilize after this many cycles; empirically determined
-    # after running all combinations of gc's with / without -d:release
-  var memPrevious = 0
-  var memMin = int.high # right after a peak
-  var numCollections = 0
-
-let numIter = when isDeterministic: 1_000 else: 1_000_000
-  ## full collection is expensive, and the memory doesn't change after
-  ## each iteration so there's no point in a large `numIter` (this was taking
-  ## 350s for `nim c -r -d:release --gc:boehm` + `nim c -r --gc:boehm`, 50%
-  ## of running time of `testament/testament all`.
-
 proc inProc() =
-  for i in 1 .. numIter:
-    when collectAlways: GC_fullcollect()
+  for i in 1 .. 1_000_000:
+    when defined(gcMarkAndSweep) or defined(boehmgc):
+      GC_fullcollect()
     var obj: TTestObj
     obj = makeObj()
-    let mem = getOccupiedMem()
-    when isDeterministic:
-      if i <= numIterStable:
-        memMax = mem
-        doAssert memMax <= 50_000 # adjust as needed
-      else:
-        # memory shouldn't increase after 1st few iterations
-        # on linux 386 it somehow takes 3 iters to converge
-        doAssert mem <= memMax
-    else:
-      if mem < memPrevious:
-        # a collection happened, it peaked at memPrevious
-        # echo (mem, memMin, memMax, numCollections, numIter, i) # for debugging
-        numCollections.inc
-        if numCollections <= numCycleStable:
-          # this is the 1st few collections, we update the min/max
-          doAssert memPrevious < 300_000 # adjust as needed
-          if memMin < mem: # `<` intentional; the valley may increase 
-            memMin = mem
-          if memMax < memPrevious:
-            memMax = memPrevious
-        else:
-          # after a collection, we always go back to same level
-          doAssert mem <= memMin, $(mem, memMin)
-
-      if numCollections >= numCycleStable:
-        # after a few cycles, the max stabilizes
-        doAssert mem <= memMax, $(mem, memMax)
-
-      memPrevious = mem
+    if getOccupiedMem() > 300_000: quit("still a leak!")
 
 inProc()
-let mem = getOccupiedMem()
-var msg = "no leak: "
-when isDeterministic:
-  msg.add $(mem, memMax)
-  echo msg
-else:
-  msg.add $(mem, memMin, memMax, numCollections, numIter)
-  echo msg
-  # make sure some collections did happen, otherwise the previous tests
-  # are meaningless
-  doAssert numCollections > 1000 # 3999 on local OSX; leaving some slack
+echo "no leak: ", getOccupiedMem()

--- a/tests/gc/gcleak2.nim
+++ b/tests/gc/gcleak2.nim
@@ -2,6 +2,11 @@ discard """
   outputsub: "no leak: "
 """
 
+## this test makes sure getOccupiedMem() is constant after a few iterations
+## for --gc:bohem, --gc:markAndSweep, --gc:arc, --gc:orc.
+## and for other gc, it consists of cycles with constant min/max after a few cycles.
+## This ensures we have no leaks.
+
 when defined(GC_setMaxPause):
   GC_setMaxPause 2_000
 
@@ -14,13 +19,75 @@ proc makeObj(): TTestObj =
   result.x = "Hello"
   result.s = @[1,2,3]
 
+const collectAlways = defined(gcMarkAndSweep) or defined(boehmgc)
+const isDeterministic = collectAlways or defined(gcArc) or defined(gcOrc)
+  ## when isDeterministic, we expect memory to reach a fixed point
+  ## after `numIterStable` iterations
+
+var memMax = 0 # peak
+
+when isDeterministic:
+  const numIterStable = 3
+    # stabilize after this many iterations
+else:
+  const numCycleStable = when defined(useRealtimeGC): 6 else: 4
+    # stabilize after this many cycles; empirically determined
+    # after running all combinations of gc's with / without -d:release
+  var memPrevious = 0
+  var memMin = int.high # right after a peak
+  var numCollections = 0
+
+let numIter = when isDeterministic: 1_000 else: 1_000_000
+  ## full collection is expensive, and the memory doesn't change after
+  ## each iteration so there's no point in a large `numIter` (this was taking
+  ## 350s for `nim c -r -d:release --gc:boehm` + `nim c -r --gc:boehm`, 50%
+  ## of running time of `testament/testament all`.
+
 proc inProc() =
-  for i in 1 .. 1_000_000:
-    when defined(gcMarkAndSweep) or defined(boehmgc):
-      GC_fullcollect()
+  for i in 1 .. numIter:
+    when collectAlways: GC_fullcollect()
     var obj: TTestObj
     obj = makeObj()
-    if getOccupiedMem() > 300_000: quit("still a leak!")
+    let mem = getOccupiedMem()
+    when isDeterministic:
+      if i <= numIterStable:
+        memMax = mem
+        doAssert memMax <= 50_000 # adjust as needed
+      else:
+        # memory shouldn't increase after 1st few iterations
+        # on linux 386 it somehow takes 3 iters to converge
+        doAssert mem <= memMax
+    else:
+      if mem < memPrevious:
+        # a collection happened, it peaked at memPrevious
+        # echo (mem, memMin, memMax, numCollections, numIter, i) # for debugging
+        numCollections.inc
+        if numCollections <= numCycleStable:
+          # this is the 1st few collections, we update the min/max
+          doAssert memPrevious < 300_000 # adjust as needed
+          if memMin < mem: # `<` intentional; the valley may increase 
+            memMin = mem
+          if memMax < memPrevious:
+            memMax = memPrevious
+        else:
+          # after a collection, we always go back to same level
+          doAssert mem <= memMin, $(mem, memMin)
+
+      if numCollections >= numCycleStable:
+        # after a few cycles, the max stabilizes
+        doAssert mem <= memMax, $(mem, memMax)
+
+      memPrevious = mem
 
 inProc()
-echo "no leak: ", getOccupiedMem()
+let mem = getOccupiedMem()
+var msg = "no leak: "
+when isDeterministic:
+  msg.add $(mem, memMax)
+  echo msg
+else:
+  msg.add $(mem, memMin, memMax, numCollections, numIter)
+  echo msg
+  # make sure some collections did happen, otherwise the previous tests
+  # are meaningless
+  doAssert numCollections > 1000 # 3999 on local OSX; leaving some slack

--- a/tests/metatype/ttypedesc2.nim
+++ b/tests/metatype/ttypedesc2.nim
@@ -35,8 +35,22 @@ type Point[T] = tuple[x, y: T]
 proc origin(T: typedesc): Point[T] = discard
 discard origin(int)
 
+block: # issue #12704
+  const a = $("a", "b")
+  proc fun() =
+    const str = $int
+    let b = $(str, "asdf")
+  fun()
+
 # https://github.com/nim-lang/Nim/issues/7516
 import typetraits
+
+block: #issue #12704
+  const a = $("a", "b")
+  proc fun() =
+    const str = name(int)
+    let b = $(str, "asdf")
+  fun()
 
 proc hasDefault1(T: type = int): auto = return T.name
 doAssert hasDefault1(int) == "int"

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -128,7 +128,6 @@ block: # lenTuple
   doAssert T2.lenTuple == 2
 
 block genericParams:
-
   type Foo[T1, T2]=object
   doAssert genericParams(Foo[float, string]) is (float, string)
   type Foo1 = Foo[float, int]
@@ -139,6 +138,50 @@ block genericParams:
   doAssert genericParams(Foo2).get(1) is Foo1
   doAssert (int,).get(0) is int
   doAssert (int, float).get(1) is float
+
+  type Bar[N: static int, T] = object
+  type Bar3 = Bar[3, float]
+  doAssert genericParams(Bar3) is (StaticParam[3], float)
+  doAssert genericParams(Bar3).get(0) is StaticParam
+  doAssert genericParams(Bar3).get(0).value == 3
+  doAssert genericParams(Bar[3, float]).get(0).value == 3
+
+  type
+    VectorElementType = SomeNumber | bool
+    Vec[N: static[int], T: VectorElementType] = object
+      arr: array[N, T]
+    Vec4[T: VectorElementType] = Vec[4,T]
+    Vec4f = Vec4[float32]
+
+    MyTupleType = (int,float,string)
+    MyGenericTuple[T] = (T,int,float)
+    MyGenericAlias = MyGenericTuple[string]
+    MyGenericTuple2[T,U] = (T,U,string)
+    MyGenericTuple2Alias[T] =  MyGenericTuple2[T,int]
+    MyGenericTuple2Alias2 =   MyGenericTuple2Alias[float]
+
+  doAssert genericParams(MyGenericAlias) is (string,)
+  doAssert genericHead(MyGenericAlias) is MyGenericTuple
+  doAssert genericParams(MyGenericTuple2Alias2) is (float,)
+  doAssert genericParams(MyGenericTuple2[float, int]) is (float, int)
+  doAssert genericParams(MyGenericAlias) is (string,)
+  doAssert genericParams(Vec4f) is (float32,)
+  doAssert genericParams(Vec[4, bool]) is (StaticParam[4], bool)
+
+  block:
+    type Foo[T1, T2]=object
+    doAssert genericParams(Foo[float, string]) is (float, string)
+    type Bar[N: static float, T] = object
+    doAssert genericParams(Bar[1.0, string]) is (StaticParam[1.0], string)
+    type Bar2 = Bar[2.0, string]
+    doAssert genericParams(Bar2) is (StaticParam[2.0], string)
+    type Bar3 = Bar[1.0 + 2.0, string]
+    doAssert genericParams(Bar3) is (StaticParam[3.0], string)
+
+    const F = 5.0
+    type Bar4 = Bar[F, string]
+    doAssert genericParams(Bar4) is (StaticParam[5.0], string)
+    doAssert genericParams(Bar[F, string]) is (StaticParam[5.0], string)
 
 ##############################################
 # bug 13095

--- a/tests/osproc/texitcode.nim
+++ b/tests/osproc/texitcode.nim
@@ -19,5 +19,8 @@ doAssert(waitForExit(p) == QuitFailure)
 
 # make sure that first call to running() after process exit returns false
 p = startProcess(filename, dir)
-os.sleep(500)
+for j in 0..<30: # refs #13449
+  os.sleep(50)
+  if not running(p): break
 doAssert(not running(p))
+doAssert(waitForExit(p) == QuitFailure) # avoid zombies

--- a/tests/stdlib/thttpcore.nim
+++ b/tests/stdlib/thttpcore.nim
@@ -4,7 +4,7 @@ output: "[Suite] httpcore"
 
 import unittest
 
-import httpcore
+import httpcore, strutils
 
 suite "httpcore":
 
@@ -29,3 +29,8 @@ suite "httpcore":
     assert "baR" in h["cookiE"]
     h.del("coOKie")
     assert h.len == 0
+
+    # Test that header constructor works with repeated values
+    let h1 = newHttpHeaders({"a": "1", "a": "2", "A": "3"})
+
+    assert seq[string](h1["a"]).join(",") == "1,2,3"

--- a/tests/stdlib/tintsets.nim
+++ b/tests/stdlib/tintsets.nim
@@ -1,0 +1,65 @@
+import intsets
+import std/sets
+
+from sequtils import toSeq
+from algorithm import sorted
+
+proc sortedPairs[T](t: T): auto = toSeq(t.pairs).sorted
+template sortedItems(t: untyped): untyped = sorted(toSeq(t))
+
+block: # we use HashSet as groundtruth, it's well tested elsewhere
+  template testDel(t, t0) =
+
+    template checkEquals() =
+      doAssert t.len == t0.len
+      for k in t0:
+        doAssert k in t
+      for k in t:
+        doAssert k in t0
+
+      doAssert sortedItems(t) == sortedItems(t0)
+
+    template incl2(i) =
+      t.incl i
+      t0.incl i
+
+    template excl2(i) =
+      t.excl i
+      t0.excl i
+
+    block:
+      var expected: seq[int]
+      let n = 100
+      let n2 = n*2
+      for i in 0..<n:
+        incl2(i)
+      checkEquals()
+      for i in 0..<n:
+        if i mod 3 == 0:
+          if i < n div 2:
+            excl2(i)
+          else:
+            t0.excl i
+            doAssert i in t
+            doAssert not t.missingOrExcl(i)
+
+      checkEquals()
+      for i in n..<n2:
+        incl2(i)
+      checkEquals()
+      for i in 0..<n2:
+        if i mod 7 == 0:
+          excl2(i)
+      checkEquals()
+
+      # notin check
+      for i in 0..<t.len:
+        if i mod 7 == 0:
+          doAssert i notin t0
+          doAssert i notin t
+          # issue #13505
+          doAssert t.missingOrExcl(i)
+
+  var t: IntSet
+  var t0: HashSet[int]
+  testDel(t, t0)

--- a/tests/stdlib/tjson_unmarshall.nim
+++ b/tests/stdlib/tjson_unmarshall.nim
@@ -1,0 +1,31 @@
+discard """
+  output: '''
+Original: (kind: P, pChildren: @[(kind: Text, textStr: "mychild"), (kind: Br)])
+jsonNode: {"kind":"P","pChildren":[{"kind":"Text","textStr":"mychild"},{"kind":"Br"}]}
+Reversed: (kind: P, pChildren: @[(kind: Text, textStr: "mychild"), (kind: Br)])
+'''
+"""
+
+import json
+
+type
+  ContentNodeKind* = enum
+    P,
+    Br,
+    Text,
+  ContentNode* = object
+    case kind*: ContentNodeKind
+    of P: pChildren*: seq[ContentNode]
+    of Br: nil
+    of Text: textStr*: string
+
+let mynode = ContentNode(kind: P, pChildren: @[
+  ContentNode(kind: Text, textStr: "mychild"),
+  ContentNode(kind: Br)
+])
+ 
+echo "Original: " & $mynode
+
+let jsonNode = %*mynode
+echo "jsonNode: " & $jsonNode
+echo "Reversed: " & $jsonNode.to(ContentNode)

--- a/tests/stdlib/tnetdial.nim
+++ b/tests/stdlib/tnetdial.nim
@@ -2,6 +2,7 @@ discard """
   cmd: "nim c --threads:on $file"
   exitcode: 0
   output: "OK"
+  disabled: "travis"
 """
 
 import os, net, nativesockets, asyncdispatch

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -389,6 +389,19 @@ block ospaths:
   doAssert joinPath("foo", "./") == unixToNativePath"foo/"
   doAssert joinPath("foo", "", "bar/") == unixToNativePath"foo/bar/"
 
+  # issue #13579
+  doAssert joinPath("/foo", "../a") == unixToNativePath"/a"
+  doAssert joinPath("/foo/", "../a") == unixToNativePath"/a"
+  doAssert joinPath("/foo/.", "../a") == unixToNativePath"/a"
+  doAssert joinPath("/foo/.b", "../a") == unixToNativePath"/foo/a"
+  doAssert joinPath("/foo///", "..//a/") == unixToNativePath"/a/"
+  doAssert joinPath("foo/", "../a") == unixToNativePath"a"
+
+  when doslikeFileSystem:
+    doAssert joinPath("C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\", "..\\..\\VC\\vcvarsall.bat") == r"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
+    doAssert joinPath("C:\\foo", "..\\a") == r"C:\a"
+    doAssert joinPath("C:\\foo\\", "..\\a") == r"C:\a"
+
 block getTempDir:
   block TMPDIR:
     # TMPDIR env var is not used if either of these are defined.

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -357,14 +357,37 @@ block ospaths:
     doAssert relativePath(r"\\foo\bar\baz.nim", r"\foo") == r"\\foo\bar\baz.nim"
     doAssert relativePath(r"c:\foo.nim", r"\foo") == r"c:\foo.nim"
 
-  doAssert joinPath("usr", "") == unixToNativePath"usr/"
+  doAssert joinPath("usr", "") == unixToNativePath"usr"
   doAssert joinPath("", "lib") == "lib"
   doAssert joinPath("", "/lib") == unixToNativePath"/lib"
   doAssert joinPath("usr/", "/lib") == unixToNativePath"usr/lib"
-  doAssert joinPath("", "") == unixToNativePath""
-  doAssert joinPath("/" / "") == unixToNativePath"/"
+  doAssert joinPath("", "") == unixToNativePath"" # issue #13455
+  doAssert joinPath("", "/") == unixToNativePath"/"
+  doAssert joinPath("/", "/") == unixToNativePath"/"
+  doAssert joinPath("/", "") == unixToNativePath"/"
+  doAssert joinPath("/" / "") == unixToNativePath"/" # weird test case...
   doAssert joinPath("/", "/a/b/c") == unixToNativePath"/a/b/c"
   doAssert joinPath("foo/","") == unixToNativePath"foo/"
+  doAssert joinPath("foo/","abc") == unixToNativePath"foo/abc"
+  doAssert joinPath("foo//./","abc/.//") == unixToNativePath"foo/abc/"
+  doAssert joinPath("foo","abc") == unixToNativePath"foo/abc"
+  doAssert joinPath("","abc") == unixToNativePath"abc"
+
+  doAssert joinPath("gook/.","abc") == unixToNativePath"gook/abc"
+
+  # controversial: inconsistent with `joinPath("gook/.","abc")`
+  # on linux, `./foo` and `foo` are treated a bit differently for executables
+  # but not `./foo/bar` and `foo/bar`
+  doAssert joinPath(".", "/lib") == unixToNativePath"./lib"
+  doAssert joinPath(".","abc") == unixToNativePath"./abc"
+  
+  # cases related to issue #13455
+  doAssert joinPath("foo", "", "") == "foo"
+  doAssert joinPath("foo", "") == "foo"
+  doAssert joinPath("foo/", "") == unixToNativePath"foo/"
+  doAssert joinPath("foo/", ".") == "foo"
+  doAssert joinPath("foo", "./") == unixToNativePath"foo/"
+  doAssert joinPath("foo", "", "bar/") == unixToNativePath"foo/bar/"
 
 block getTempDir:
   block TMPDIR:

--- a/tests/stdlib/tsharedtable.nim
+++ b/tests/stdlib/tsharedtable.nim
@@ -6,10 +6,84 @@ output: '''
 
 import sharedtables
 
-var table: SharedTable[int, int]
+block:
+  var table: SharedTable[int, int]
 
-init(table)
-table[1] = 10
-assert table.mget(1) == 10
-assert table.mgetOrPut(3, 7) == 7
-assert table.mgetOrPut(3, 99) == 7
+  init(table)
+  table[1] = 10
+  assert table.mget(1) == 10
+  assert table.mgetOrPut(3, 7) == 7
+  assert table.mgetOrPut(3, 99) == 7
+  deinitSharedTable(table)
+
+import sequtils, algorithm
+proc sortedPairs[T](t: T): auto = toSeq(t.pairs).sorted
+template sortedItems(t: untyped): untyped = sorted(toSeq(t))
+
+import tables # refs issue #13504
+
+block: # we use Table as groundtruth, it's well tested elsewhere
+  template testDel(t, t0) =
+    template put2(i) =
+      t[i] = i
+      t0[i] = i
+
+    template add2(i, val) =
+      t.add(i, val)
+      t0.add(i, val)
+
+    template del2(i) =
+      t.del(i)
+      t0.del(i)
+
+    template checkEquals() =
+      doAssert t.len == t0.len
+      for k,v in t0:
+        doAssert t.mgetOrPut(k, -1) == v # sanity check
+        doAssert t.mget(k) == v
+
+    let n = 100
+    let n2 = n*2
+    let n3 = n*3
+    let n4 = n*4
+    let n5 = n*5
+
+    for i in 0..<n:
+      put2(i)
+    for i in 0..<n:
+      if i mod 3 == 0:
+        del2(i)
+    for i in n..<n2:
+      put2(i)
+    for i in 0..<n2:
+      if i mod 7 == 0:
+        del2(i)
+
+    checkEquals()
+
+    for i in n2..<n3:
+      t0[i] = -2
+      doAssert t.mgetOrPut(i, -2) == -2
+      doAssert t.mget(i) == -2
+
+    for i in 0..<n4:
+      let ok = i in t0
+      if not ok: t0[i] = -i
+      doAssert t.hasKeyOrPut(i, -i) == ok
+
+    checkEquals()
+
+    for i in n4..<n5:
+      add2(i, i*10)
+      add2(i, i*11)
+      add2(i, i*12)
+      del2(i)
+      del2(i)
+
+    checkEquals()
+
+  var t: SharedTable[int, int]
+  init(t) # ideally should be auto-init
+  var t0: Table[int, int]
+  testDel(t, t0)
+  deinitSharedTable(t)

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -345,20 +345,24 @@ suite "ttimes":
   test "adding/subtracting TimeInterval":
     # add/subtract TimeIntervals and Time/TimeInfo
     let now = getTime().utc
+    let isSpecial = now.isLeapDay
     check now + convert(Seconds, Nanoseconds, 1).nanoseconds == now + 1.seconds
     check now + 1.weeks == now + 7.days
     check now - 1.seconds == now - 3.seconds + 2.seconds
     check now + 65.seconds == now + 1.minutes + 5.seconds
     check now + 60.minutes == now + 1.hours
     check now + 24.hours == now + 1.days
-    check now + 13.months == now + 1.years + 1.months
+    if not isSpecial:
+      check now + 13.months == now + 1.years + 1.months
     check toUnix(fromUnix(0) + 2.seconds) == 2
     check toUnix(fromUnix(0) - 2.seconds) == -2
     var ti1 = now + 1.years
     ti1 = ti1 - 1.years
-    check ti1 == now
+    if not isSpecial:
+      check ti1 == now
     ti1 = ti1 + 1.days
-    check ti1 == now + 1.days
+    if not isSpecial:
+      check ti1 == now + 1.days
 
     # Bug with adding a day to a Time
     let day = 24.hours

--- a/tests/system/tsystem_misc.nim
+++ b/tests/system/tsystem_misc.nim
@@ -193,3 +193,20 @@ block:
     a = {k1}
     b = {k1,k2}
   doAssert a < b
+
+
+block: # Ordinal
+  doAssert int is Ordinal
+  doAssert uint is Ordinal
+  doAssert int64 is Ordinal
+  doAssert uint64 is Ordinal
+  doAssert char is Ordinal
+  type Foo = enum k1, k2
+  doAssert Foo is Ordinal
+  doAssert Foo is SomeOrdinal
+  doAssert enum is SomeOrdinal
+
+  # these fail:
+  # doAssert enum is Ordinal # fails
+  # doAssert Ordinal is SomeOrdinal
+  # doAssert SomeOrdinal is Ordinal

--- a/tests/types/tissues_types.nim
+++ b/tests/types/tissues_types.nim
@@ -8,6 +8,8 @@ ptr Foo
 (member: 123.456)
 (member: "hello world", x: ...)
 (member: 123.456, x: ...)
+0
+false
 '''
 joinable: false
 """
@@ -78,3 +80,31 @@ block t7905:
 
   foobarRec("hello world")
   foobarRec(123.456'f64)
+
+# bug #5170
+
+when true:
+  type Foo = object
+    bar: bool
+
+  type Bar = object
+    sameBody: string
+
+  var b0: Bar
+  b0.sameBody = "abc"
+
+block:
+  type Foo = object
+    baz: int
+
+  type Bar = object
+    sameBody: string
+
+  var b1: Bar
+  b1.sameBody = "def"
+
+  var f2: Foo
+  echo f2.baz
+
+var f1: Foo
+echo f1.bar

--- a/tests/varres/tprevent_forloopvar_mutations.nim
+++ b/tests/varres/tprevent_forloopvar_mutations.nim
@@ -3,9 +3,9 @@ discard """
   line: 17
   nimout: '''type mismatch: got <int>
 but expected one of:
-proc inc[T: Ordinal | uint | uint64](x: var T; y = 1)
+proc inc[T: Ordinal](x: var T; y = 1)
   first type mismatch at position: 1
-  required type for x: var T: Ordinal or uint or uint64
+  required type for x: var T: Ordinal
   but expression 'i' is immutable, not 'var'
 
 expression: inc i

--- a/tests/vm/tcompilesetting.nim
+++ b/tests/vm/tcompilesetting.nim
@@ -1,0 +1,19 @@
+discard """
+cmd: "nim c --nimcache:myNimCache --nimblePath:myNimblePath $file"
+joinable: false
+"""
+
+import strutils
+
+import std / compilesettings
+
+const
+  nc = querySetting(nimcacheDir)
+  np = querySettingSeq(nimblePaths)
+
+static:
+  echo nc
+  echo np
+
+doAssert "myNimCache" in nc
+doAssert "myNimblePath" in np[0]

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -1,6 +1,6 @@
 ## Part of 'koch' responsible for the documentation generation.
 
-import os, strutils, osproc, sets
+import os, strutils, osproc, sets, pathnorm
 
 const
   gaCode* = " --doc.googleAnalytics:UA-48159761-1"
@@ -195,11 +195,11 @@ lib/system/widestrs.nim
        a.isRelativeTo("lib/pure/includes") or
        a.isRelativeTo("lib/genode") or
        a.isRelativeTo("lib/deprecated") or
-       (a.isRelativeTo("lib/system") and a notin goodSystem) or
-       a in docIgnore:
+       (a.isRelativeTo("lib/system") and a.replace('\\', '/') notin goodSystem) or
+       a.replace('\\', '/') in docIgnore:
          continue
     result.add a
-  result.add "nimsuggest/sexp.nim"
+  result.add normalizePath("nimsuggest/sexp.nim")
 
 let doc = getDocList()
 

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -232,7 +232,10 @@ compiler/ccgstmts.nim
 compiler/ccgthreadvars.nim
 compiler/ccgtrav.nim
 compiler/ccgtypes.nim
+compiler/hlo.nim
 compiler/jstypes.nim
+compiler/packagehandling.nim
+compiler/rodimpl.nim
 compiler/semcall.nim
 compiler/semexprs.nim
 compiler/semfields.nim
@@ -245,30 +248,33 @@ compiler/semtempl.nim
 compiler/semtypes.nim
 compiler/sizealignoffsetimpl.nim
 compiler/suggest.nim
-compiler/packagehandling.nim
-compiler/hlo.nim
-compiler/rodimpl.nim
-compiler/vmops.nim
 compiler/vmhooks.nim
+compiler/vmops.nim
 """.splitWhitespace()
 
   # not include files but doesn't work; not included/imported anywhere; dead code?
   const bad = """
-compiler/debuginfo.nim
 compiler/canonicalizer.nim
+compiler/debuginfo.nim
 compiler/forloops.nim
 """.splitWhitespace()
 
   # these cause errors even though they're imported (some of which are mysterious)
   const bad2 = """
+compiler/aliases.nim
+compiler/ast.nim
+compiler/astalgo.nim
 compiler/closureiters.nim
-compiler/tccgen.nim
+compiler/evalffi.nim
 compiler/lambdalifting.nim
 compiler/layouter.nim
-compiler/evalffi.nim
 compiler/nimfix/nimfix.nim
 compiler/plugins/active.nim
 compiler/plugins/itersgen.nim
+compiler/renderer.nim
+compiler/tccgen.nim
+compiler/trees.nim
+compiler/types.nim
 """.splitWhitespace()
 
   for a in walkDirRec("compiler"):

--- a/tools/nimgrep.nim
+++ b/tools/nimgrep.nim
@@ -649,7 +649,8 @@ else:
     if optIgnoreStyle in options:
       pattern = styleInsensitive(pattern)
     if optWord in options:
-      pattern = r"\b(:?" & pattern & r")\b"
+      # see https://github.com/nim-lang/Nim/issues/13528#issuecomment-592786443
+      pattern = r"(^|\W)(:?" & pattern & r")($|\W)"
     if {optIgnoreCase, optIgnoreStyle} * options != {}:
       reflags.incl reIgnoreCase
     let rep = if optRex in options: rex(pattern, reflags)

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -513,7 +513,8 @@ template gatherFiles(fun, libpath, outDir) =
       fun(src, dst)
 
     for f in walkFiles(libpath / "lib/*.h"): copySrc(f)
-    copySrc(libpath / "lib/wrappers/linenoise/linenoise.h")
+    # commenting out for now, see discussion in https://github.com/nim-lang/Nim/pull/13413
+    # copySrc(libpath / "lib/wrappers/linenoise/linenoise.h")
 
 proc srcdist(c: var ConfigData) =
   let cCodeDir = getOutputDir(c) / "c_code"


### PR DESCRIPTION
this seems like a general optimization strategy we could use in other places:

this
```nim
    for c in mitems(s):
      c = chr(c.ord + (if c.isUpperAscii: (ord('a') - ord('A')) else: 0))
```

is 11X faster than:

```nim
    for c in mitems(s):
      if c.isUpperAscii: c = chr(ord(c) + (ord('a') - ord('A')))
```

## benchmark
https://github.com/timotheecour/vitanim/blob/master/testcases/t10332d.nim
git clone https://github.com/timotheecour/vitanim && cd vitanim
```
nim c -r --skipparentcfg --skipusercfg --hints:off -d:danger --lib:lib -f $vitanim_D/testcases/t10332d.nim
```
6.1570 for this https://github.com/nim-lang/Nim/pull/13610
0.573082 for this PR https://github.com/timotheecour/Nim/pull/54

## scratch below here
* maybe (or not...) related: https://stackoverflow.com/questions/11276291/why-cant-or-doesnt-the-compiler-optimize-a-predictable-addition-loop-into-a
* https://stackoverflow.com/questions/11227809/why-is-processing-a-sorted-array-faster-than-processing-an-unsorted-array
* maybe it relates to write hazards and branch prediction; writing on contiguous memory locations (as I'm doing here) seems to be faster than writing at random array locations

