### PR TITLE
Improve parser errors

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -2044,7 +2044,7 @@ proc myClose(graph: ModuleGraph; b: PPassContext, n: PNode): PNode =
     if m.config.exc == excGoto and getCompilerProc(graph, "nimTestErrorFlag") != nil:
       discard cgsym(m, "nimTestErrorFlag")
 
-    if {optGenStaticLib, optGenDynLib} * m.config.globalOptions == {}:
+    if {optGenStaticLib, optGenDynLib, optNoMain} * m.config.globalOptions == {}:
       for i in countdown(high(graph.globalDestructors), 0):
         n.add graph.globalDestructors[i]
   if passes.skipCodegen(m.config, n): return

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -192,6 +192,9 @@ const
   errInvalidIndentation = "invalid indentation"
   errIdentifierExpected = "identifier expected, but got '$1'"
   errExprExpected = "expression expected, but found '$1'"
+  errInvalidIndentRoutine = """possible errors:
+  * invalid indentation of top level statement
+  * missing `=` to implement previous routine"""
 
 proc skipInd(p: var Parser) =
   if p.tok.indent >= 0:
@@ -2325,7 +2328,10 @@ proc parseTopLevelStmt(p: var Parser): PNode =
           parMessage(p, errGenerated,
             "invalid indentation; an export marker '*' follows the declared identifier")
         else:
-          parMessage(p, errInvalidIndentation)
+          if p.prevParserLevel == plRoutine:
+            parMessage(p, errInvalidIndentRoutine)
+          else:
+            parMessage(p, errInvalidIndentation)
     p.firstTok = false
     case p.tok.tokType
     of tkSemiColon:

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -228,7 +228,6 @@ proc parLineInfo(p: Parser): TLineInfo =
 proc indAndComment(p: var Parser, n: PNode) =
   if p.tok.indent > p.currInd:
     if p.tok.tokType == tkComment: rawSkipComment(p, n)
-    else: parMessage(p, errInvalidIndentation)
   else:
     skipComment(p, n)
 

--- a/tests/parser/t1566_invalid_indent_missing_equals.nim
+++ b/tests/parser/t1566_invalid_indent_missing_equals.nim
@@ -1,0 +1,12 @@
+discard """
+  action: "reject"
+  nimout: '''
+t1566_invalid_indent_missing_equals.nim(12, 3) Error: possible errors:
+  * invalid indentation of top level statement
+  * missing `=` to implement previous routine
+'''
+"""
+
+# line 10
+proc fn(n: int) {.exportc.}
+  echo 1


### PR DESCRIPTION
### Prerequisite

refs nim-lang#15667

Explorative work to improve the parser's invalid indentation message, following thoughts laid out in:

* https://github.com/nim-lang/Nim/issues/15667#issuecomment-737990355
* https://github.com/nim-lang/Nim/issues/15667#issuecomment-738894684

I am openly looking for discussion and direction on this matter. 

### Work

I have determined that `incAndComment` is looking for doc comments. By the grammar, doc comments are optional, so I have concluded an error should not be emitted in this case. Then to fix the common case outlined in nim-lang#15667, it requires to check a routine was previously parsed when attempting to parse a top level statement. This is done by adding an `enum` field to the Parser and checking against it.

I plan on to continue looking at other cases and following a similar solution.

### Side Note: `indAndComment()`

```
proc indAndComment(p: var Parser, n: PNode) =
  if p.tok.indent > p.currInd:
    if p.tok.tokType == tkComment: rawSkipComment(p, n)
    else: parMessage(p, errInvalidIndentation)
  else:
    skipComment(p, n)

proc optPar(p: var Parser) =
  if p.tok.indent >= 0:
    if p.tok.indent < p.currInd: parMessage(p, errInvalidIndentation)
```

I believe that the `invalid indentation` message that is outputted is unneeded and incorrect. For two reasons

1. In the grammar, `indAndComment` are optional. Any invalid indentation here should be ignored and interpreted as something else.
2. `indAndComment` only cares about an indentation increase with a comment or a comment. So an error would occur if the indentation is incorrect or it did not found a doc comment. Currently `indAndComment` checks if the indentation is correct, then if it is a doc comment. If it is not a doc comment, it emits an error of invalid indentation, even though the indentation is not incorrect. For comparison, look at `optPar`. It only emits an invalid indentation error when the indentation has decreased.


