### PR TITLE
[superseded] fix #16265; fix #13999 (HCR on OSX); cgen now does not line wrap string litterals 

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1556,6 +1556,9 @@ proc registerModuleToMain(g: BModuleList; m: BModule) =
       # nasty nasty hack to get the command line functionality working with HCR
       # register the 2 variables on behalf of the os module which might not even
       # be loaded (in which case it will get collected but that is not a problem)
+      # EDIT: indeed, this hack, in combination with another un-necessary hack
+      # (`makeCString` was doing line wrap of string litterals) was root cause for
+      # bug #16265.
       let osModulePath = ($systemModulePath).replace("stdlib_system", "stdlib_os").rope
       g.mainDatInit.addf("\thcrAddModule($1);\n", [osModulePath])
       g.mainDatInit.add("\tint* cmd_count;\n")

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1556,7 +1556,7 @@ proc registerModuleToMain(g: BModuleList; m: BModule) =
       # nasty nasty hack to get the command line functionality working with HCR
       # register the 2 variables on behalf of the os module which might not even
       # be loaded (in which case it will get collected but that is not a problem)
-      # EDIT: indeed, this hack, in combination with another un-necessary hack
+      # EDIT: indeed, this hack, in combination with another un-necessary one
       # (`makeCString` was doing line wrap of string litterals) was root cause for
       # bug #16265.
       let osModulePath = ($systemModulePath).replace("stdlib_system", "stdlib_os").rope

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -34,13 +34,15 @@ proc toCChar*(c: char; result: var string) =
     result.add c
 
 proc makeCString*(s: string): Rope =
-  const MaxLineLength = 64
   result = nil
   var res = newStringOfCap(int(s.len.toFloat * 1.1) + 1)
   res.add("\"")
   for i in 0..<s.len:
-    if (i + 1) mod MaxLineLength == 0:
-      res.add("\"\L\"")
+    # line wrapping of string litterals in cgen'd code was a bad idea, e.g. causes: bug #16265
+    # It also makes reading c sources or grepping harder, for zero benefit.
+    # const MaxLineLength = 64
+    # if (i + 1) mod MaxLineLength == 0:
+    #   res.add("\"\L\"")
     toCChar(s[i], res)
   res.add('\"')
   result.add(rope(res))

--- a/tests/dll/nimhcr_integration.nim
+++ b/tests/dll/nimhcr_integration.nim
@@ -1,7 +1,4 @@
 discard """
-  disabled: "openbsd"
-  disabled: "netbsd"
-  disabled: "macosx"
   output: '''
 main: HELLO!
 main: hasAnyModuleChanged? true
@@ -100,6 +97,7 @@ proc compileReloadExecute() =
   #   binary triggers rebuilding itself here it shouldn't rebuild the main module -
   #   that would lead to replacing the main binary executable which is running!
   let cmd = commandLineParams()[0..^1].join(" ").replace(" --forceBuild")
+  doAssert cmd.len > 0
   let (stdout, exitcode) = execCmdEx(cmd)
   if exitcode != 0:
     echo "COMPILATION ERROR!"


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/16265
fix https://github.com/nim-lang/Nim/issues/13999

When you combine 2 ugly hacks you get those kind of bugs...

This was really painful to debug.

=> https://github.com/nim-lang/Nim/pull/16329