### PR TITLE
write system.abs in nim, not magic

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -607,7 +607,8 @@ var
     ## might exclude {tfGcSafe, tfNoSideEffect}.
 
 type
-  TMagic* = enum # symbols that require compiler magic:
+  TMagic* = enum # Symbols that require compiler magic.
+                 # These can be removed or renamed if needed.
     mNone,
     mDefined, mDeclared, mDeclaredInScope, mCompiles, mArrGet, mArrPut, mAsgn,
     mLow, mHigh, mSizeOf, mAlignOf, mOffsetOf, mTypeTrait,
@@ -633,7 +634,7 @@ type
     mEqB, mLeB, mLtB,
     mEqRef, mLePtr, mLtPtr,
     mXor, mEqCString, mEqProc,
-    mUnaryMinusI, mUnaryMinusI64, mAbsI, mNot,
+    mUnaryMinusI, mUnaryMinusI64, mNot,
     mUnaryPlusI, mBitnotI,
     mUnaryPlusF64, mUnaryMinusF64,
     mCharToStr, mBoolToStr, mIntToStr, mInt64ToStr, mFloatToStr, mCStrToStr,
@@ -702,7 +703,7 @@ const
     mEqCh, mLeCh, mLtCh,
     mEqB, mLeB, mLtB,
     mEqRef, mEqProc, mLePtr, mLtPtr, mEqCString, mXor,
-    mUnaryMinusI, mUnaryMinusI64, mAbsI, mNot, mUnaryPlusI, mBitnotI,
+    mUnaryMinusI, mUnaryMinusI64, mNot, mUnaryPlusI, mBitnotI,
     mUnaryPlusF64, mUnaryMinusF64,
     mCharToStr, mBoolToStr, mIntToStr, mInt64ToStr, mFloatToStr, mCStrToStr,
     mStrToStr, mEnumToStr,

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -601,8 +601,6 @@ proc unaryArithOverflow(p: BProc, e: PNode, d: var TLoc, m: TMagic) =
     putIntoDest(p, d, e, "((NI$2)-($1))" % [rdLoc(a), rope(getSize(p.config, t) * 8)])
   of mUnaryMinusI64:
     putIntoDest(p, d, e, "-($1)" % [rdLoc(a)])
-  of mAbsI:
-    putIntoDest(p, d, e, "($1 > 0? ($1) : -($1))" % [rdLoc(a)])
   else:
     assert(false, $m)
 
@@ -2249,7 +2247,7 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
   case op
   of mOr, mAnd: genAndOr(p, e, d, op)
   of mNot..mUnaryMinusF64: unaryArith(p, e, d, op)
-  of mUnaryMinusI..mAbsI: unaryArithOverflow(p, e, d, op)
+  of mUnaryMinusI..mUnaryMinusI64: unaryArithOverflow(p, e, d, op)
   of mAddF64..mDivF64: binaryFloatArith(p, e, d, op)
   of mShrI..mXor: binaryArith(p, e, d, op)
   of mEqProc: genEqProc(p, e, d)

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -425,7 +425,6 @@ const # magic checked op; magic unchecked op;
     mEqProc: ["", ""],
     mUnaryMinusI: ["negInt", ""],
     mUnaryMinusI64: ["negInt64", ""],
-    mAbsI: ["absInt", ""],
     mNot: ["", ""],
     mUnaryPlusI: ["", ""],
     mBitnotI: ["", ""],
@@ -647,7 +646,6 @@ proc arithAux(p: PProc, n: PNode, r: var TCompRes, op: TMagic) =
   of mEqProc: applyFormat("($1 == $2)", "($1 == $2)")
   of mUnaryMinusI: applyFormat("negInt($1)", "-($1)")
   of mUnaryMinusI64: applyFormat("negInt64($1)", "-($1)")
-  of mAbsI: applyFormat("absInt($1)", "Math.abs($1)")
   of mNot: applyFormat("!($1)", "!($1)")
   of mUnaryPlusI: applyFormat("+($1)", "+($1)")
   of mBitnotI: applyFormat("~($1)", "~($1)")

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -138,7 +138,6 @@ proc evalOp(m: TMagic, n, a, b, c: PNode; g: ModuleGraph): PNode =
       result = newIntNodeT(toInt128(a.len), n, g)
   of mUnaryPlusI, mUnaryPlusF64: result = a # throw `+` away
   # XXX: Hides overflow/underflow
-  of mAbsI: result = foldAbs(getInt(a), n, g)
   of mSucc: result = foldAdd(getOrdValue(a), getInt(b), n, g)
   of mPred: result = foldSub(getOrdValue(a), getInt(b), n, g)
   of mAddI: result = foldAdd(getInt(a), getInt(b), n, g)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1310,7 +1310,7 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
     if dest < 0: dest = c.getTemp(n.typ)
     c.gABC(n, opcCallSite, dest)
   of mNGenSym: genBinaryABC(c, n, dest, opcGenSym)
-  of mMinI, mMaxI, mAbsI, mDotDot:
+  of mMinI, mMaxI, mDotDot:
     c.genCall(n, dest)
   of mExpandToAst:
     if n.len != 2:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1891,6 +1891,16 @@ else:
   # Autodetect coroutine support.
   const nimCoroutines* = false
 
+{.push stackTrace: off.}
+func abs*[T: SomeSignedInt](x: T): T {.inline.} =
+  ## Returns the absolute value of `x`.
+  runnableExamples:
+    doAssert abs(-3) == 3
+    doAssertRaises(OverflowDefect): discard abs(int8.low)
+    doAssertRaises(OverflowDefect): discard abs(int64.low)
+  if x < 0: -x else: x
+{.pop.}
+
 {.push checks: off.}
 # obviously we cannot generate checking operations here :-)
 # because it would yield into an endless recursion
@@ -2027,25 +2037,6 @@ proc getTypeInfo*[T](x: T): pointer {.magic: "GetTypeInfo", benign.}
   ##
   ## Ordinary code should not use this, but the `typeinfo module
   ## <typeinfo.html>`_ instead.
-
-{.push stackTrace: off.}
-# func abs*(x: int): int {.magic: "AbsI", inline.} =
-#   if x < 0: -x else: x
-# func abs*(x: int8): int8 {.magic: "AbsI", inline.} =
-#   if x < 0: -x else: x
-# func abs*(x: int16): int16 {.magic: "AbsI", inline.} =
-#   if x < 0: -x else: x
-# func abs*(x: int32): int32 {.magic: "AbsI", inline.} =
-#   if x < 0: -x else: x
-# func abs*(x: int64): int64 {.magic: "AbsI", inline.} =
-func abs*[T: SomeSignedInt](x: T): T {.inline.} =
-  ## Returns the absolute value of `x`.
-  ##
-  ## If `x` is ``low(x)`` (that is -MININT for its type),
-  ## an overflow exception is thrown (if overflow checking is turned on).
-  # result = if x < 0: -x else: x
-  if x < 0: -x else: x
-{.pop.}
 
 when not defined(js):
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2029,20 +2029,22 @@ proc getTypeInfo*[T](x: T): pointer {.magic: "GetTypeInfo", benign.}
   ## <typeinfo.html>`_ instead.
 
 {.push stackTrace: off.}
-func abs*(x: int): int {.magic: "AbsI", inline.} =
-  if x < 0: -x else: x
-func abs*(x: int8): int8 {.magic: "AbsI", inline.} =
-  if x < 0: -x else: x
-func abs*(x: int16): int16 {.magic: "AbsI", inline.} =
-  if x < 0: -x else: x
-func abs*(x: int32): int32 {.magic: "AbsI", inline.} =
-  if x < 0: -x else: x
-func abs*(x: int64): int64 {.magic: "AbsI", inline.} =
+# func abs*(x: int): int {.magic: "AbsI", inline.} =
+#   if x < 0: -x else: x
+# func abs*(x: int8): int8 {.magic: "AbsI", inline.} =
+#   if x < 0: -x else: x
+# func abs*(x: int16): int16 {.magic: "AbsI", inline.} =
+#   if x < 0: -x else: x
+# func abs*(x: int32): int32 {.magic: "AbsI", inline.} =
+#   if x < 0: -x else: x
+# func abs*(x: int64): int64 {.magic: "AbsI", inline.} =
+func abs*[T: SomeSignedInt](x: T): T {.inline.} =
   ## Returns the absolute value of `x`.
   ##
   ## If `x` is ``low(x)`` (that is -MININT for its type),
   ## an overflow exception is thrown (if overflow checking is turned on).
-  result = if x < 0: -x else: x
+  # result = if x < 0: -x else: x
+  if x < 0: -x else: x
 {.pop.}
 
 when not defined(js):

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1891,9 +1891,10 @@ else:
   # Autodetect coroutine support.
   const nimCoroutines* = false
 
-{.push stackTrace: off.}
+{.push stackTrace: off.} # pre-existing but seems un-necessary
 func abs*[T: SomeSignedInt](x: T): T {.inline.} =
   ## Returns the absolute value of `x`.
+  # xxx consider consolidating this with `abs(float)` overload.
   runnableExamples:
     doAssert abs(-3) == 3
     doAssertRaises(OverflowDefect): discard abs(int8.low)

--- a/lib/system/arithm.nim
+++ b/lib/system/arithm.nim
@@ -130,12 +130,6 @@ proc negInt64(a: int64): int64 {.compilerproc, inline.} =
   if a != low(int64): return -a
   raiseOverflow()
 
-proc absInt64(a: int64): int64 {.compilerproc, inline.} =
-  if a != low(int64):
-    if a >= 0: return a
-    else: return -a
-  raiseOverflow()
-
 proc divInt64(a, b: int64): int64 {.compilerproc, inline.} =
   if b == int64(0):
     raiseDivByZero()
@@ -147,12 +141,6 @@ proc modInt64(a, b: int64): int64 {.compilerproc, inline.} =
   if b == int64(0):
     raiseDivByZero()
   return a mod b
-
-proc absInt(a: int): int {.compilerproc, inline.} =
-  if a != low(int):
-    if a >= 0: return a
-    else: return -a
-  raiseOverflow()
 
 const
   asmVersion = defined(I386) and (defined(vcc) or defined(wcc) or

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -508,12 +508,6 @@ proc nimFloatToString(a: float): cstring {.compilerproc.} =
     }
   """
 
-proc absInt(a: int): int {.compilerproc.} =
-  result = if a < 0: a*(-1) else: a
-
-proc absInt64(a: int64): int64 {.compilerproc.} =
-  result = if a < 0: a*(-1) else: a
-
 when not defined(nimNoZeroExtendMagic):
   proc ze*(a: int): int {.compilerproc.} =
     result = a

--- a/tests/stdlib/tsystem.nim
+++ b/tests/stdlib/tsystem.nim
@@ -20,8 +20,11 @@ template main() =
         doAssertRaises(OverflowDefect): discard abs(int32.low)
         doAssertRaises(OverflowDefect): discard abs(int64.low)
 
+  block: # `-`
     let a = low(int)
-    doAssertRaises(OverflowDefect): discard -a
+    disableVM:
+      when not defined(js):
+        doAssertRaises(OverflowDefect): discard -a
 
 static: main()
 main()

--- a/tests/stdlib/tsystem.nim
+++ b/tests/stdlib/tsystem.nim
@@ -10,14 +10,18 @@ template disableVM(body): untyped =
   else: body
 
 template main() =
-  doAssert abs(0) == 0
-  doAssert abs(int.high) == int.high
-  doAssert abs(-3) == 3
-  disableVM: # xxx bug: in vm, we get an un-recoverable program abort.
-    when not defined(js): # xxx bug: these should raise in js
-      doAssertRaises(OverflowDefect): discard abs(int8.low)
-      doAssertRaises(OverflowDefect): discard abs(int32.low)
-      doAssertRaises(OverflowDefect): discard abs(int64.low)
+  block: # abs
+    doAssert abs(0) == 0
+    doAssert abs(int.high) == int.high
+    doAssert abs(-3) == 3
+    disableVM: # xxx bug: in vm, we get an un-recoverable program abort.
+      when not defined(js): # xxx bug: these should raise in js
+        doAssertRaises(OverflowDefect): discard abs(int8.low)
+        doAssertRaises(OverflowDefect): discard abs(int32.low)
+        doAssertRaises(OverflowDefect): discard abs(int64.low)
+
+    let a = low(int)
+    doAssertRaises(OverflowDefect): discard -a
 
 static: main()
 main()

--- a/tests/stdlib/tsystem.nim
+++ b/tests/stdlib/tsystem.nim
@@ -10,11 +10,13 @@ template disableVM(body): untyped =
   else: body
 
 template main() =
+  doAssert abs(0) == 0
+  doAssert abs(int.high) == int.high
   doAssert abs(-3) == 3
-  disableVM:
-    doAssertRaises(OverflowDefect): discard abs(int8.low)
-    doAssertRaises(OverflowDefect): discard abs(int32.low)
-    when not defined(js):
+  disableVM: # xxx bug: in vm, we get an un-recoverable program abort.
+    when not defined(js): # xxx bug: these should raise in js
+      doAssertRaises(OverflowDefect): discard abs(int8.low)
+      doAssertRaises(OverflowDefect): discard abs(int32.low)
       doAssertRaises(OverflowDefect): discard abs(int64.low)
 
 static: main()

--- a/tests/stdlib/tsystem.nim
+++ b/tests/stdlib/tsystem.nim
@@ -1,0 +1,21 @@
+discard """
+  joinable: false
+  targets: "c cpp js"
+"""
+
+# xxx consolidate / refactor with tests/system/tsystem_misc.nim, etc
+
+template disableVM(body): untyped =
+  when nimvm: discard
+  else: body
+
+template main() =
+  doAssert abs(-3) == 3
+  disableVM:
+    doAssertRaises(OverflowDefect): discard abs(int8.low)
+    doAssertRaises(OverflowDefect): discard abs(int32.low)
+    when not defined(js):
+      doAssertRaises(OverflowDefect): discard abs(int64.low)
+
+static: main()
+main()


### PR DESCRIPTION
refs https://github.com/timotheecour/Nim/issues/476#issuecomment-751312006

## subtlety
before PR, `nim r main` does't raise
after PR, `nim r main` raises `OverflowDefect` because `abs` is now a regular proc.
note, if i change `abs` to a template, this would preserve pre-existing behavior, ie not raise here.
```nim
when true:
  {.push overflowChecks: off.}
  proc main()=
    let a = abs(int64.low)
  main()
  {.pop.}
```
```nim
template abs*[T: SomeSignedInt](x: T): T =
  let x2 = x
  if x2 < 0: -x2 else: x2
```
vs:
```nim
func abs*[T: SomeSignedInt](x: T): T {.inline.} =
  if x < 0: -x else: x
```

## note
if we want to make an inner proc (eg abs) be affected by a pragma (eg `overflowChecks:off`), there are 2 ways:
* use a template (simplest but in the general case might not be desirable in all cases)
* use a proc (generic or not), but make it implicitly generic on the "environment", in this case the pragma `overflowChecks:off`, so that 2 distinct procs could end up being instantiated in the same program: one with  `overflowChecks:on` and one with  `overflowChecks:off`

## note 2
global flags `-d:danger` aren't affected by this, this is just regarding semantics for a local `{.push overflowChecks: off.}`

## note 3
maybe implicitly generic idea (depending on "environment") could be used in other contexts, eg to generate 2 distinct procs depending on whether we're in vm or not (eg for improving nimvm semantics)