### PR TITLE
[superseded] bring back std/ prefix within compiler and ensure it works in bootstrap + bsd

### DIFF
--- a/compiler/ic/dce.nim
+++ b/compiler/ic/dce.nim
@@ -9,7 +9,7 @@
 
 ## Dead code elimination (=DCE) for IC.
 
-import intsets, tables
+import std / [intsets, tables]
 import ".." / [ast, options, lineinfos, types]
 
 import packed_ast, ic, bitabs


### PR DESCRIPTION
* refs https://github.com/nim-lang/Nim/pull/16282#discussion_r616846863
* sounds very similar to https://github.com/nim-lang/Nim/pull/14291
EDIT
superseded by https://github.com/nim-lang/Nim/pull/17902